### PR TITLE
feat(propagate): add `--show-diffs` flag on `propagate plan` (#5)

### DIFF
--- a/cmd/monoco/commands.go
+++ b/cmd/monoco/commands.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"text/tabwriter"
 
 	"github.com/matt0x6f/monoco/internal/propagate"
@@ -30,6 +31,7 @@ func cmdPropagatePlan(root string, args []string) {
 	fs := flag.NewFlagSet("propagate plan", flag.ExitOnError)
 	since := fs.String("since", "", "base ref")
 	slug := fs.String("slug", "", "train tag slug (default: current branch)")
+	showDiffs := fs.Bool("show-diffs", false, "also print unified diffs of proposed go.mod rewrites")
 	fs.Parse(args)
 	if *since == "" {
 		fatal(fmt.Errorf("--since is required"))
@@ -43,6 +45,29 @@ func cmdPropagatePlan(root string, args []string) {
 		fatal(err)
 	}
 	printPlan(plan)
+	if *showDiffs && len(plan.Entries) > 0 {
+		printPlanDiffs(ws, plan)
+	}
+}
+
+func printPlanDiffs(ws *workspace.Workspace, plan *propagate.Plan) {
+	rewrites, err := propagate.ComputeRewrites(ws, plan)
+	if err != nil {
+		fatal(err)
+	}
+	if len(rewrites) == 0 {
+		return
+	}
+	fmt.Println()
+	// Iterate in plan.Entries order for deterministic output (topo order).
+	for _, e := range plan.Entries {
+		r, ok := rewrites[e.ModulePath]
+		if !ok {
+			continue
+		}
+		display := filepath.Join(ws.Modules[e.ModulePath].RelDir, "go.mod")
+		fmt.Print(propagate.UnifiedDiff(display, r.Old, r.New))
+	}
 }
 
 func cmdPropagateApply(root string, args []string) {

--- a/cmd/monoco/main_test.go
+++ b/cmd/monoco/main_test.go
@@ -51,6 +51,20 @@ func TestCLI_endToEnd(t *testing.T) {
 		t.Errorf("plan output missing v0.2.0; got: %s", out)
 	}
 
+	// `monoco propagate plan --since HEAD~1 --show-diffs` — summary plus
+	// unified diff for api/go.mod (the only entry with an in-plan require to rewrite).
+	out = runCLI(t, bin, fx.Root, "propagate", "plan", "--since", "HEAD~1", "--show-diffs")
+	for _, want := range []string{
+		"MODULE",
+		"--- modules/api/go.mod",
+		"+++ modules/api/go.mod (proposed)",
+		"+require example.com/mono/storage v0.2.0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plan --show-diffs missing %q; got:\n%s", want, out)
+		}
+	}
+
 	// `monoco propagate apply --since HEAD~1 --remote=origin`
 	out = runCLI(t, bin, fx.Root, "propagate", "apply", "--since", "HEAD~1", "--remote", "origin", "--slug", "e2e")
 	if !strings.Contains(out, "Pushed to origin") {

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/matt0x6f/monoco
 go 1.25.0
 
 require golang.org/x/mod v0.35.0
+
+require github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=

--- a/internal/propagate/apply.go
+++ b/internal/propagate/apply.go
@@ -108,28 +108,41 @@ func Apply(ws *workspace.Workspace, plan *Plan, opts ApplyOptions) (*ApplyResult
 	return result, nil
 }
 
-// rewriteGoMods rewrites each entry's require lines to new versions of
-// other entries also in the plan.
-func rewriteGoMods(ws *workspace.Workspace, plan *Plan) error {
+// RewrittenMod is the proposed result of rewriting a single go.mod.
+// Only modules whose go.mod actually changes are returned by ComputeRewrites.
+type RewrittenMod struct {
+	GoModPath string // absolute path to go.mod
+	Old       []byte // current bytes on disk
+	New       []byte // proposed bytes after applying the plan's version bumps
+}
+
+// ComputeRewrites returns the proposed go.mod rewrites for plan, in memory.
+// It does not touch the filesystem. Both Apply and `propagate plan --show-diffs`
+// consume this so the preview is byte-identical to what apply writes.
+//
+// The returned map is keyed by Entry.ModulePath. Modules whose go.mod has no
+// in-plan require to update are omitted (no change to write).
+func ComputeRewrites(ws *workspace.Workspace, plan *Plan) (map[string]RewrittenMod, error) {
 	newVersions := map[string]string{}
 	for _, e := range plan.Entries {
 		newVersions[e.ModulePath] = e.NewVersion
 	}
+	out := map[string]RewrittenMod{}
 	for _, e := range plan.Entries {
 		goModPath := filepath.Join(ws.Modules[e.ModulePath].Dir, "go.mod")
 		b, err := os.ReadFile(goModPath)
 		if err != nil {
-			return fmt.Errorf("read %s: %w", goModPath, err)
+			return nil, fmt.Errorf("read %s: %w", goModPath, err)
 		}
 		mf, err := modfile.Parse(goModPath, b, nil)
 		if err != nil {
-			return fmt.Errorf("parse %s: %w", goModPath, err)
+			return nil, fmt.Errorf("parse %s: %w", goModPath, err)
 		}
 		changed := false
 		for _, req := range mf.Require {
 			if newV, inPlan := newVersions[req.Mod.Path]; inPlan {
 				if err := mf.AddRequire(req.Mod.Path, newV); err != nil {
-					return fmt.Errorf("update require %s: %w", req.Mod.Path, err)
+					return nil, fmt.Errorf("update require %s: %w", req.Mod.Path, err)
 				}
 				changed = true
 			}
@@ -138,12 +151,25 @@ func rewriteGoMods(ws *workspace.Workspace, plan *Plan) error {
 			continue
 		}
 		mf.Cleanup()
-		out, err := mf.Format()
+		formatted, err := mf.Format()
 		if err != nil {
-			return fmt.Errorf("format %s: %w", goModPath, err)
+			return nil, fmt.Errorf("format %s: %w", goModPath, err)
 		}
-		if err := os.WriteFile(goModPath, out, 0o644); err != nil {
-			return fmt.Errorf("write %s: %w", goModPath, err)
+		out[e.ModulePath] = RewrittenMod{GoModPath: goModPath, Old: b, New: formatted}
+	}
+	return out, nil
+}
+
+// rewriteGoMods rewrites each entry's require lines to new versions of
+// other entries also in the plan.
+func rewriteGoMods(ws *workspace.Workspace, plan *Plan) error {
+	rewrites, err := ComputeRewrites(ws, plan)
+	if err != nil {
+		return err
+	}
+	for _, r := range rewrites {
+		if err := os.WriteFile(r.GoModPath, r.New, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", r.GoModPath, err)
 		}
 	}
 	return nil

--- a/internal/propagate/diff.go
+++ b/internal/propagate/diff.go
@@ -1,0 +1,36 @@
+package propagate
+
+import (
+	"strings"
+
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// UnifiedDiff renders a unified diff (3 lines of context) between oldBytes
+// and newBytes. The displayPath is used in the `---` / `+++` headers; the
+// "+++" side is suffixed with " (proposed)" so reviewers can tell at a glance
+// that the right-hand side hasn't been written to disk yet.
+//
+// If the inputs are byte-identical, returns the empty string.
+func UnifiedDiff(displayPath string, oldBytes, newBytes []byte) string {
+	if string(oldBytes) == string(newBytes) {
+		return ""
+	}
+	d := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(oldBytes)),
+		B:        difflib.SplitLines(string(newBytes)),
+		FromFile: displayPath,
+		ToFile:   displayPath + " (proposed)",
+		Context:  3,
+	}
+	out, err := difflib.GetUnifiedDiffString(d)
+	if err != nil {
+		// difflib's writer only fails if the underlying io.Writer fails;
+		// strings.Builder never errors. Treat as no-diff rather than panic.
+		return ""
+	}
+	if !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	return out
+}

--- a/internal/propagate/diff_test.go
+++ b/internal/propagate/diff_test.go
@@ -1,0 +1,93 @@
+package propagate
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/matt0x6f/monoco/internal/fixture"
+	"github.com/matt0x6f/monoco/internal/workspace"
+)
+
+func TestComputeRewrites_andUnifiedDiff(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "api", DependsOn: []string{"storage"}},
+		},
+	})
+	run(t, fx.Root, "git", "tag", "modules/storage/v0.1.0")
+	run(t, fx.Root, "git", "tag", "modules/api/v0.1.0")
+
+	base := headSHA(t, fx.Root)
+	writeFile(t, filepath.Join(fx.Root, "modules/storage/storage.go"),
+		"package storage\n\nfunc StorageHello() string { return \"new\" }\nfunc Batch() string { return \"batch\" }\n")
+	run(t, fx.Root, "git", "add", "-A")
+	run(t, fx.Root, "git", "commit", "-m", "feat(storage): add batch")
+
+	ws, err := workspace.Load(fx.Root)
+	if err != nil {
+		t.Fatalf("workspace.Load: %v", err)
+	}
+	plan, err := NewPlan(ws, base, "HEAD", Options{Slug: "test"})
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+
+	statusBefore := gitStatus(t, fx.Root)
+
+	rewrites, err := ComputeRewrites(ws, plan)
+	if err != nil {
+		t.Fatalf("ComputeRewrites: %v", err)
+	}
+
+	// Working tree must be untouched — ComputeRewrites is read-only.
+	if got := gitStatus(t, fx.Root); got != statusBefore {
+		t.Errorf("ComputeRewrites mutated working tree.\nbefore:\n%s\nafter:\n%s", statusBefore, got)
+	}
+
+	// storage is a leaf direct bump — no in-plan require to update, so it's omitted.
+	if _, ok := rewrites["example.com/mono/storage"]; ok {
+		t.Errorf("storage has no in-plan require rewrite; should be omitted from rewrites map")
+	}
+	apiRewrite, ok := rewrites["example.com/mono/api"]
+	if !ok {
+		t.Fatalf("expected rewrite for api; got keys %v", keys(rewrites))
+	}
+	if !strings.Contains(string(apiRewrite.New), "example.com/mono/storage v0.2.0") {
+		t.Errorf("rewrite did not bump storage to v0.2.0:\n%s", apiRewrite.New)
+	}
+	// Old should be the actual bytes on disk before any rewrite — the fixture
+	// uses the modfile placeholder version, which the test deliberately does
+	// not assume; we just assert it does NOT already contain v0.2.0.
+	if strings.Contains(string(apiRewrite.Old), "example.com/mono/storage v0.2.0") {
+		t.Errorf("Old should not already contain the new version:\n%s", apiRewrite.Old)
+	}
+
+	diff := UnifiedDiff("modules/api/go.mod", apiRewrite.Old, apiRewrite.New)
+	for _, want := range []string{
+		"--- modules/api/go.mod",
+		"+++ modules/api/go.mod (proposed)",
+		"-require example.com/mono/storage ",
+		"+require example.com/mono/storage v0.2.0",
+	} {
+		if !strings.Contains(diff, want) {
+			t.Errorf("diff missing %q.\nfull diff:\n%s", want, diff)
+		}
+	}
+}
+
+func TestUnifiedDiff_identicalReturnsEmpty(t *testing.T) {
+	got := UnifiedDiff("foo.txt", []byte("hello\n"), []byte("hello\n"))
+	if got != "" {
+		t.Errorf("expected empty diff for identical input; got %q", got)
+	}
+}
+
+func keys(m map[string]RewrittenMod) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #5.

## Why
`propagate plan` only shows a summary table today. Reviewers of high-stakes releases want to see the exact `go.mod` bytes that `apply` would write — without doing the destructive dry-run that running `apply` requires.

## What
New flag: `monoco propagate plan --since <ref> --show-diffs` prints the existing summary table, then a unified diff per affected `go.mod`. Output is standard unified diff so it can be piped to `delta`, `less`, etc.

```
--- modules/api/go.mod
+++ modules/api/go.mod (proposed)
@@ -2,5 +2,5 @@

 go 1.22

-require example.com/mono/storage v0.1.0
+require example.com/mono/storage v0.2.0
```

## How
The risky failure mode here is **drift** between the preview and what `apply` actually writes. To avoid it, `rewriteGoMods` is split into:

- `ComputeRewrites(ws, plan) -> map[modulePath]RewrittenMod` — pure, in-memory; returns `{Old, New}` byte pairs.
- A thin writer in `rewriteGoMods` that just calls `os.WriteFile` for each entry.

Both `apply` and `propagate plan --show-diffs` consume `ComputeRewrites`, so the diff preview is byte-identical to what apply will commit.

Unified-diff rendering uses `github.com/pmezard/go-difflib` — pure Go, zero transitive deps, BSD-licensed, stable for a decade (used by `testify`). Alternative considered: shelling to `git diff --no-index`, which would need temp files and a writable index. The library is cleaner.

## Notes for reviewers
- Entries that have no in-plan `require` to update (leaf direct bumps, or root direct bumps with no in-plan deps) legitimately produce no diff — they're silently skipped beneath the summary table that already listed them. The `propagate apply` path's `if !changed { continue }` semantic is preserved.
- The flag is not added to `propagate apply`; apply prints the summary, plan is the preview surface.
- New test `TestComputeRewrites_andUnifiedDiff` asserts the working tree is unchanged after `ComputeRewrites` runs — guards against accidental future regression.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — full suite green
- [x] New unit test for `ComputeRewrites` + `UnifiedDiff` (`internal/propagate/diff_test.go`)
- [x] End-to-end CLI test for `--show-diffs` extended in `cmd/monoco/main_test.go`
- [ ] Manual smoke against a real workspace and pipe through `| delta`