### PR TITLE
feat(propagate): add --modules flag to scope propagation (#3)

### DIFF
--- a/cmd/monoco/commands.go
+++ b/cmd/monoco/commands.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/matt0x6f/monoco/internal/propagate"
@@ -30,15 +31,13 @@ func cmdPropagatePlan(root string, args []string) {
 	fs := flag.NewFlagSet("propagate plan", flag.ExitOnError)
 	since := fs.String("since", "", "base ref")
 	slug := fs.String("slug", "", "train tag slug (default: current branch)")
+	modules := fs.String("modules", "", "comma-separated module list (RelDir or module path); skips diff-based affected-set")
 	fs.Parse(args)
-	if *since == "" {
-		fatal(fmt.Errorf("--since is required"))
-	}
 	ws, err := workspace.Load(root)
 	if err != nil {
 		fatal(err)
 	}
-	plan, err := propagate.NewPlan(ws, *since, "HEAD", propagate.Options{Slug: *slug})
+	plan, err := buildPropagatePlan(ws, *since, *modules, propagate.Options{Slug: *slug})
 	if err != nil {
 		fatal(err)
 	}
@@ -50,15 +49,13 @@ func cmdPropagateApply(root string, args []string) {
 	since := fs.String("since", "", "base ref")
 	slug := fs.String("slug", "", "train tag slug (default: current branch)")
 	remote := fs.String("remote", "origin", "remote to push to; set to \"\" to skip push")
+	modules := fs.String("modules", "", "comma-separated module list (RelDir or module path); skips diff-based affected-set")
 	fs.Parse(args)
-	if *since == "" {
-		fatal(fmt.Errorf("--since is required"))
-	}
 	ws, err := workspace.Load(root)
 	if err != nil {
 		fatal(err)
 	}
-	plan, err := propagate.NewPlan(ws, *since, "HEAD", propagate.Options{Slug: *slug})
+	plan, err := buildPropagatePlan(ws, *since, *modules, propagate.Options{Slug: *slug})
 	if err != nil {
 		fatal(err)
 	}
@@ -79,6 +76,51 @@ func cmdPropagateApply(root string, args []string) {
 	} else {
 		fmt.Println("Not pushed (remote unset or push skipped).")
 	}
+}
+
+// buildPropagatePlan dispatches to NewPlan or NewPlanForModules based on which
+// of --since / --modules was set, and enforces mutual exclusion.
+func buildPropagatePlan(ws *workspace.Workspace, since, modules string, opts propagate.Options) (*propagate.Plan, error) {
+	if since != "" && modules != "" {
+		return nil, fmt.Errorf("--since and --modules are mutually exclusive; pick one")
+	}
+	if since == "" && modules == "" {
+		return nil, fmt.Errorf("must specify --since or --modules")
+	}
+	if modules != "" {
+		refs, err := splitModulesList(modules)
+		if err != nil {
+			return nil, err
+		}
+		paths := make([]string, 0, len(refs))
+		for _, r := range refs {
+			p, ok := propagate.ResolveModuleRef(ws, r)
+			if !ok {
+				return nil, fmt.Errorf("module %q not found in workspace", r)
+			}
+			paths = append(paths, p)
+		}
+		return propagate.NewPlanForModules(ws, paths, opts)
+	}
+	return propagate.NewPlan(ws, since, "HEAD", opts)
+}
+
+// splitModulesList parses the --modules CSV value, trimming whitespace and
+// rejecting empty entries.
+func splitModulesList(v string) ([]string, error) {
+	raw := strings.Split(v, ",")
+	out := make([]string, 0, len(raw))
+	for _, s := range raw {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return nil, fmt.Errorf("--modules has empty entry")
+		}
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("--modules is empty")
+	}
+	return out, nil
 }
 
 func printPlan(plan *propagate.Plan) {

--- a/cmd/monoco/commands_test.go
+++ b/cmd/monoco/commands_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/matt0x6f/monoco/internal/propagate"
+	"github.com/matt0x6f/monoco/internal/workspace"
+)
+
+func TestSplitModulesList(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    []string
+		wantErr bool
+	}{
+		{"a", []string{"a"}, false},
+		{"a,b,c", []string{"a", "b", "c"}, false},
+		{" a , b ", []string{"a", "b"}, false},
+		{"a,,b", nil, true},
+		{",a", nil, true},
+		{"", nil, true},
+	}
+	for _, tc := range cases {
+		got, err := splitModulesList(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("splitModulesList(%q) err=%v wantErr=%v", tc.in, err, tc.wantErr)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		if len(got) != len(tc.want) {
+			t.Errorf("splitModulesList(%q) = %v, want %v", tc.in, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("splitModulesList(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestBuildPropagatePlan_mutuallyExclusiveFlags(t *testing.T) {
+	// Workspace isn't touched on the rejection path; a zero workspace is fine.
+	ws := &workspace.Workspace{Modules: map[string]workspace.Module{}}
+
+	_, err := buildPropagatePlan(ws, "HEAD~1", "modules/api", propagate.Options{})
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected mutually-exclusive error, got: %v", err)
+	}
+
+	_, err = buildPropagatePlan(ws, "", "", propagate.Options{})
+	if err == nil || !strings.Contains(err.Error(), "must specify") {
+		t.Errorf("expected 'must specify' error, got: %v", err)
+	}
+}

--- a/cmd/monoco/main_test.go
+++ b/cmd/monoco/main_test.go
@@ -58,6 +58,42 @@ func TestCLI_endToEnd(t *testing.T) {
 	}
 }
 
+// TestCLI_propagatePlanModulesFlag verifies that --modules scopes the plan to
+// exactly the listed modules, ignoring the diff.
+func TestCLI_propagatePlanModulesFlag(t *testing.T) {
+	bin := buildCLI(t)
+
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "api", DependsOn: []string{"storage"}},
+		},
+	})
+	runT(t, fx.Root, "git", "tag", "modules/storage/v0.1.0")
+	runT(t, fx.Root, "git", "tag", "modules/api/v0.1.0")
+
+	// Edit storage — a diff-based plan would cascade api; --modules api should not.
+	writeFile(t, filepath.Join(fx.Root, "modules/storage/storage.go"),
+		"package storage\n\nfunc StorageHello() string { return \"new\" }\n")
+	runT(t, fx.Root, "git", "add", "-A")
+	runT(t, fx.Root, "git", "commit", "-m", "feat(storage): tweak")
+
+	out := runCLI(t, bin, fx.Root, "propagate", "plan", "--modules", "modules/api")
+	if !strings.Contains(out, "example.com/mono/api") {
+		t.Errorf("plan missing api: %s", out)
+	}
+	if strings.Contains(out, "example.com/mono/storage") {
+		t.Errorf("plan should not include storage when --modules=api: %s", out)
+	}
+
+	// Mutual exclusion: --since + --modules must error.
+	cmd := exec.Command(bin, "propagate", "plan", "--since", "HEAD~1", "--modules", "modules/api")
+	cmd.Dir = fx.Root
+	if err := cmd.Run(); err == nil {
+		t.Error("expected error combining --since with --modules")
+	}
+}
+
 func buildCLI(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/propagate/plan.go
+++ b/internal/propagate/plan.go
@@ -62,19 +62,87 @@ func NewPlan(ws *workspace.Workspace, oldRef, newRef string, opts Options) (*Pla
 	for _, m := range direct {
 		directSet[m] = struct{}{}
 	}
-
 	all := affected.Compute(ws, direct)
-	if len(all) == 0 {
+	return buildPlan(ws, all, directSet, oldRef, newRef, opts)
+}
+
+// NewPlanForModules computes a plan from an explicit module list: no diff,
+// no transitive expansion. Each listed module is treated as directly changed.
+// modulePaths must be module paths (e.g. "example.com/mono/api") already
+// resolved against the workspace; use ResolveModuleRef to accept RelDir inputs.
+func NewPlanForModules(ws *workspace.Workspace, modulePaths []string, opts Options) (*Plan, error) {
+	if len(modulePaths) == 0 {
+		return nil, fmt.Errorf("no modules specified")
+	}
+	seen := map[string]struct{}{}
+	directSet := map[string]struct{}{}
+	ordered := make([]string, 0, len(modulePaths))
+	for _, mp := range modulePaths {
+		if _, ok := ws.Modules[mp]; !ok {
+			known := make([]string, 0, len(ws.Modules))
+			for p := range ws.Modules {
+				known = append(known, p)
+			}
+			sort.Strings(known)
+			return nil, fmt.Errorf("module %q not found in workspace (known: %s)", mp, strings.Join(known, ", "))
+		}
+		if _, dup := seen[mp]; dup {
+			continue
+		}
+		seen[mp] = struct{}{}
+		directSet[mp] = struct{}{}
+		ordered = append(ordered, mp)
+	}
+	return buildPlan(ws, ordered, directSet, "", "HEAD", opts)
+}
+
+// ResolveModuleRef accepts either a module path (as in go.mod) or a RelDir
+// (as in go.work `use`) and returns the canonical module path. The boolean
+// indicates whether the input resolved to a known workspace module.
+func ResolveModuleRef(ws *workspace.Workspace, input string) (string, bool) {
+	if _, ok := ws.Modules[input]; ok {
+		return input, true
+	}
+	want := normalizeRelDir(input)
+	for path, mod := range ws.Modules {
+		if normalizeRelDir(mod.RelDir) == want {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+// buildPlan constructs entries for the given module set. If oldRef == "",
+// per-module commit classification uses each module's latest tag as the
+// lower bound; otherwise the shared (oldRef, newRef] range applies.
+func buildPlan(ws *workspace.Workspace, modules []string, directSet map[string]struct{}, oldRef, newRef string, opts Options) (*Plan, error) {
+	if len(modules) == 0 {
 		return &Plan{Root: ws.Root, OldRef: oldRef, NewRef: newRef, TrainTag: ""}, nil
 	}
 
 	// Classify bumps per module.
 	bumps := map[string]convco.Kind{}
-	for _, modPath := range all {
+	oldVersions := map[string]string{}
+	for _, modPath := range modules {
 		mod := ws.Modules[modPath]
+		rel := normalizeRelDir(mod.RelDir)
+		old, err := gitgraph.LatestTagForModule(ws.Root, rel)
+		if err != nil {
+			return nil, fmt.Errorf("latest tag for %s: %w", modPath, err)
+		}
+		oldVersions[modPath] = old
+
 		var kinds []convco.Kind
 		if _, isDirect := directSet[modPath]; isDirect {
-			commits, err := gitgraph.CommitsInRange(ws.Root, oldRef, newRef, normalizeRelDir(mod.RelDir))
+			from := oldRef
+			if from == "" {
+				// No global base: use this module's latest tag as the lower
+				// bound. If never tagged, leave empty so log walks full history.
+				if old != "" {
+					from = rel + "/" + old
+				}
+			}
+			commits, err := gitgraph.CommitsInRange(ws.Root, from, newRef, rel)
 			if err != nil {
 				return nil, fmt.Errorf("commits for %s: %w", modPath, err)
 			}
@@ -102,14 +170,8 @@ func NewPlan(ws *workspace.Workspace, oldRef, newRef string, opts Options) (*Pla
 
 	// Compute new versions. Reject major v1→v2 crossings for v1 of monoco.
 	versions := map[string]string{}
-	oldVersions := map[string]string{}
 	for modPath, kind := range bumps {
-		mod := ws.Modules[modPath]
-		old, err := gitgraph.LatestTagForModule(ws.Root, normalizeRelDir(mod.RelDir))
-		if err != nil {
-			return nil, fmt.Errorf("latest tag for %s: %w", modPath, err)
-		}
-		oldVersions[modPath] = old
+		old := oldVersions[modPath]
 		newV, err := convco.NextVersion(old, kind)
 		if err != nil {
 			return nil, fmt.Errorf("next version for %s: %w", modPath, err)
@@ -121,8 +183,8 @@ func NewPlan(ws *workspace.Workspace, oldRef, newRef string, opts Options) (*Pla
 	}
 
 	// Topological order over workspace reverse-dep edges restricted to
-	// the affected set. Kahn-style for determinism.
-	ordered := topoOrder(ws, all)
+	// the module set. Kahn-style for determinism.
+	ordered := topoOrder(ws, modules)
 
 	entries := make([]Entry, 0, len(ordered))
 	for _, modPath := range ordered {

--- a/internal/propagate/plan_test.go
+++ b/internal/propagate/plan_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/matt0x6f/monoco/internal/fixture"
@@ -119,6 +120,114 @@ func TestNewPlan_rejectsMajorBumpV1ToV2(t *testing.T) {
 	_, err := NewPlan(ws, base, "HEAD", Options{Slug: "test"})
 	if err == nil {
 		t.Fatal("expected NewPlan to reject v1→v2 major bump in v1 of monoco")
+	}
+}
+
+func TestNewPlanForModules_explicitListSkipsDiff(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "api", DependsOn: []string{"storage"}},
+		},
+	})
+	run(t, fx.Root, "git", "tag", "modules/storage/v0.1.0")
+	run(t, fx.Root, "git", "tag", "modules/api/v0.1.0")
+
+	// Edit storage (should be ignored by --modules mode).
+	writeFile(t, filepath.Join(fx.Root, "modules/storage/storage.go"), "package storage\n\nfunc StorageHello() string { return \"new\" }\n")
+	run(t, fx.Root, "git", "add", "-A")
+	run(t, fx.Root, "git", "commit", "-m", "feat(storage): tweak")
+
+	ws, err := workspace.Load(fx.Root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	plan, err := NewPlanForModules(ws, []string{"example.com/mono/api"}, Options{Slug: "test"})
+	if err != nil {
+		t.Fatalf("NewPlanForModules: %v", err)
+	}
+	paths := plan.ModulePaths()
+	if len(paths) != 1 || paths[0] != "example.com/mono/api" {
+		t.Fatalf("expected plan with only api, got %v", paths)
+	}
+	api := findEntry(plan, "example.com/mono/api")
+	if api == nil {
+		t.Fatal("api entry missing")
+	}
+	if !api.DirectChange {
+		t.Error("api should be DirectChange=true (explicitly listed)")
+	}
+	if api.OldVersion != "v0.1.0" || api.NewVersion != "v0.1.1" {
+		t.Errorf("api version wrong: old=%s new=%s", api.OldVersion, api.NewVersion)
+	}
+}
+
+func TestNewPlanForModules_unknownModuleError(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	ws, err := workspace.Load(fx.Root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	_, err = NewPlanForModules(ws, []string{"example.com/does/not/exist"}, Options{Slug: "test"})
+	if err == nil {
+		t.Fatal("expected error for unknown module")
+	}
+	if !strings.Contains(err.Error(), "example.com/does/not/exist") {
+		t.Errorf("error should name the bad module, got: %v", err)
+	}
+}
+
+func TestNewPlanForModules_topoOrder(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "api", DependsOn: []string{"storage"}},
+			{Name: "gateway", DependsOn: []string{"api"}},
+		},
+	})
+	for _, m := range []string{"storage", "api", "gateway"} {
+		run(t, fx.Root, "git", "tag", "modules/"+m+"/v0.1.0")
+	}
+	ws, _ := workspace.Load(fx.Root)
+	plan, err := NewPlanForModules(ws, []string{
+		"example.com/mono/gateway",
+		"example.com/mono/storage",
+		"example.com/mono/api",
+	}, Options{Slug: "test"})
+	if err != nil {
+		t.Fatalf("NewPlanForModules: %v", err)
+	}
+	order := plan.ModulePaths()
+	idx := map[string]int{}
+	for i, p := range order {
+		idx[p] = i
+	}
+	if idx["example.com/mono/storage"] >= idx["example.com/mono/api"] {
+		t.Errorf("expected storage before api: %v", order)
+	}
+	if idx["example.com/mono/api"] >= idx["example.com/mono/gateway"] {
+		t.Errorf("expected api before gateway: %v", order)
+	}
+}
+
+func TestResolveModuleRef_acceptsRelDirAndModulePath(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	ws, _ := workspace.Load(fx.Root)
+	if p, ok := ResolveModuleRef(ws, "example.com/mono/storage"); !ok || p != "example.com/mono/storage" {
+		t.Errorf("module path: got (%s, %v)", p, ok)
+	}
+	if p, ok := ResolveModuleRef(ws, "modules/storage"); !ok || p != "example.com/mono/storage" {
+		t.Errorf("RelDir: got (%s, %v)", p, ok)
+	}
+	if p, ok := ResolveModuleRef(ws, "./modules/storage"); !ok || p != "example.com/mono/storage" {
+		t.Errorf("dirty RelDir: got (%s, %v)", p, ok)
+	}
+	if _, ok := ResolveModuleRef(ws, "nope"); ok {
+		t.Error("expected not-found for bogus ref")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `--modules modA,modB` to `propagate plan` and `propagate apply`. When given, the plan is built from exactly the listed modules — no diff, no transitive expansion.
- Accepts either RelDir (`modules/api`) or the full module path. Validates each ref against the workspace, with an error that lists known modules.
- `--modules` + `--since` is rejected as mutually exclusive; one of the two is now required.
- Refactor: shared `buildPlan` now powers both `NewPlan` (diff-based) and the new `NewPlanForModules`. When no global `oldRef` is available, commit classification falls back to `(latestTagForModule, HEAD]` per module.

## Why
v1 always cascades the full transitive closure of a change. In a large monorepo that means a typo fix in a shared util can retag 100+ modules. `--modules` gives teams an escape hatch — release just what they name. It also unblocks the hand-cut hotfix flow tracked in #10.

Closes #3.

## Test plan
- [x] `go test -count=1 ./...` — all green, including new tests.
- [x] `go vet ./...` clean.
- [x] New unit tests: `NewPlanForModules` (explicit list skips diff, unknown-module error, topo order), `ResolveModuleRef` (RelDir + module path), CLI CSV parser, and `--since + --modules` mutual-exclusion.
- [x] New integration test `TestCLI_propagatePlanModulesFlag`: edits `storage`, runs `propagate plan --modules modules/api`, asserts plan lists only `api`; also asserts the mutual-exclusion error.

## Notes for reviewer
- Backwards compatible: `--since` behavior is untouched; the tag-based range fallback only activates when `oldRef == ""` (i.e. the `--modules` mode).
- `ResolveModuleRef` is exported to keep the CLI layer from needing to know about `normalizeRelDir` semantics.