### PR TITLE
feat(config): add minimal monoco.yaml manifest (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added
+
+- **Optional `monoco.yaml` manifest** at the repo root for per-module opt-outs and task command overrides. An absent manifest preserves current defaults. ([#1](https://github.com/matt0x6f/monoco/issues/1))
+  - `exclude:` — list repo-relative module dirs (same form as `go.work` use entries). Excluded modules are invisible to `affected`, `release`, and task fanout: no tags, no rewrites, not counted as consumers.
+  - `tasks.<name>.command:` — override the argv for `test`, `lint`, `build`, or `generate`. Omitted tasks keep their built-in defaults (`go test ./...`, `golangci-lint run`, etc.).
+  - Unknown keys and unrecognized task names are rejected at load time so typos aren't silently ignored.
+  - `monoco init` writes a commented stub `monoco.yaml` alongside `go.work` if none exists. Re-running `init` never clobbers an existing manifest.
+
+### Technical
+
+- New `internal/config` package. `workspace.Load` now consults the manifest and omits excluded modules from the returned graph; `workspace.LoadWithConfig` exposed for callers that need to inspect the manifest separately.
+
 ### Breaking
 
 - **`monoco propagate plan` and `monoco propagate apply` are removed.** Replaced by `monoco release` (see below). Old scripts using `propagate` must migrate to `release --bump <module>=<kind>`.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,38 @@ If anything before the push fails, the working tree and refs are restored to the
 
 Pre-1.0. Design validated by four POCs ([findings](pocs/FINDINGS.md)).
 
+## Configuration (`monoco.yaml`, optional)
+
+Drop a `monoco.yaml` at the repo root if you need to deviate from the defaults. `monoco init` writes a commented stub. An absent manifest is equivalent to:
+
+```yaml
+version: 1
+
+# Modules excluded from propagation, affected-set, and task fanout.
+# Paths match your go.work use entries.
+exclude: []
+
+# Per-task argv overrides. Omitted tasks keep their built-in defaults
+# (go test ./..., golangci-lint run, go build ./..., go generate ./...).
+tasks: {}
+```
+
+Example:
+
+```yaml
+version: 1
+exclude:
+  - modules/internal-experimental
+  - modules/private-sdk
+tasks:
+  lint:
+    command: ["golangci-lint", "run", "--timeout=5m"]
+```
+
+Excluded modules never show up in `monoco affected`, `monoco release`, or task fanout — no tags, no `go.mod` rewrites, not counted as consumers of anything.
+
 ## Not in scope (yet)
 
-- `monoco.yaml` manifest with per-module opt-outs and task command overrides.
 - v2+ major-version path rewriting.
 - Forward-propagation of orphan tags cut by hand.
 - PR creation (intentionally forge-agnostic — wrap with `gh` / `glab` / whatever).

--- a/cmd/monoco/main.go
+++ b/cmd/monoco/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/matt0x6f/monoco/internal/affected"
+	"github.com/matt0x6f/monoco/internal/config"
 	"github.com/matt0x6f/monoco/internal/gitgraph"
 	"github.com/matt0x6f/monoco/internal/tasks"
 	"github.com/matt0x6f/monoco/internal/workspace"
@@ -59,13 +60,13 @@ func main() {
 	case "affected":
 		cmdAffected(root, args)
 	case "test":
-		cmdTask(root, args, []string{"go", "test", "./..."})
+		cmdTask(root, args, "test", []string{"go", "test", "./..."})
 	case "lint":
-		cmdTask(root, args, []string{"golangci-lint", "run"})
+		cmdTask(root, args, "lint", []string{"golangci-lint", "run"})
 	case "build":
-		cmdTask(root, args, []string{"go", "build", "./..."})
+		cmdTask(root, args, "build", []string{"go", "build", "./..."})
 	case "generate":
-		cmdTask(root, args, []string{"go", "generate", "./..."})
+		cmdTask(root, args, "generate", []string{"go", "generate", "./..."})
 	case "release":
 		cmdRelease(root, args)
 	case "-h", "--help", "help":
@@ -81,7 +82,8 @@ func fatal(err error) {
 	os.Exit(1)
 }
 
-// cmdInit walks the repo for go.mod files and writes go.work.
+// cmdInit walks the repo for go.mod files and writes go.work. It also
+// drops a stub monoco.yaml alongside, if none exists yet.
 func cmdInit(root string, args []string) {
 	fs := flag.NewFlagSet("init", flag.ExitOnError)
 	fs.Parse(args)
@@ -93,6 +95,45 @@ func cmdInit(root string, args []string) {
 		fatal(err)
 	}
 	fmt.Printf("wrote go.work with %d module(s)\n", len(dirs))
+	wrote, err := writeManifestStubIfMissing(root)
+	if err != nil {
+		fatal(err)
+	}
+	if wrote {
+		fmt.Printf("wrote stub %s\n", config.Filename)
+	}
+}
+
+const manifestStub = `# monoco.yaml — optional configuration.
+# An absent manifest is equivalent to defaults below. Uncomment + edit
+# the sections you need and delete the rest; unknown keys are rejected.
+version: 1
+
+# Modules excluded from propagation (no tags, no go.mod rewrites) and
+# from affected-set / task fanout. Paths match your go.work use entries.
+# exclude:
+#   - modules/internal-experimental
+#   - modules/private-sdk
+
+# Per-task command overrides. Omitted tasks fall back to built-in
+# defaults: go test ./...  /  golangci-lint run  /  go build ./...
+# /  go generate ./...
+# tasks:
+#   lint:
+#     command: ["golangci-lint", "run", "--timeout=5m"]
+`
+
+func writeManifestStubIfMissing(root string) (bool, error) {
+	path := filepath.Join(root, config.Filename)
+	if _, err := os.Stat(path); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	if err := os.WriteFile(path, []byte(manifestStub), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // cmdSync is identical to cmdInit for v1 (idempotent).
@@ -173,13 +214,23 @@ func computeAffectedForRange(ws *workspace.Workspace, oldRef, newRef string) ([]
 	return affected.Compute(ws, direct), nil
 }
 
-// cmdTask fans out a command over the affected module set.
-func cmdTask(root string, args []string, command []string) {
+// cmdTask fans out a command over the affected module set. If
+// monoco.yaml overrides the named task's command, that override replaces
+// defaultCommand.
+func cmdTask(root string, args []string, taskName string, defaultCommand []string) {
 	fs := flag.NewFlagSet("task", flag.ExitOnError)
 	since := fs.String("since", "", "base ref (e.g. main, origin/main, SHA)")
 	all := fs.Bool("all", false, "run against every workspace module, not just affected")
 	fs.Parse(args)
-	ws, err := workspace.Load(root)
+	cfg, err := config.Load(root)
+	if err != nil {
+		fatal(err)
+	}
+	command := defaultCommand
+	if override := cfg.TaskCommand(taskName); override != nil {
+		command = override
+	}
+	ws, err := workspace.LoadWithConfig(root, cfg)
 	if err != nil {
 		fatal(err)
 	}

--- a/cmd/monoco/main_test.go
+++ b/cmd/monoco/main_test.go
@@ -146,6 +146,82 @@ func TestCLI_release_defaultsDirectToPatchWithoutBump(t *testing.T) {
 	}
 }
 
+func TestCLI_init_writesStubManifest(t *testing.T) {
+	bin := buildCLI(t)
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+
+	// init over an already-initialized fixture: go.work exists, monoco.yaml does not.
+	path := filepath.Join(fx.Root, "monoco.yaml")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("pre-condition: monoco.yaml should not exist, got err=%v", err)
+	}
+	runCLI(t, bin, fx.Root, "init")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("monoco.yaml not written by init: %v", err)
+	}
+
+	// Second init leaves the user's existing manifest alone.
+	custom := []byte("version: 1\nexclude:\n  - modules/storage\n")
+	if err := os.WriteFile(path, custom, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runCLI(t, bin, fx.Root, "init")
+	got, _ := os.ReadFile(path)
+	if string(got) != string(custom) {
+		t.Errorf("init clobbered an existing monoco.yaml:\n%s", got)
+	}
+}
+
+func TestCLI_excludedModuleIgnoredByAffected(t *testing.T) {
+	bin := buildCLI(t)
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "private", DependsOn: []string{"storage"}},
+		},
+	})
+	runT(t, fx.Root, "git", "tag", "modules/storage/v0.1.0")
+	runT(t, fx.Root, "git", "tag", "modules/private/v0.1.0")
+
+	// Exclude modules/private, then touch storage — affected should list
+	// storage but NOT private, even though private depends on it.
+	if err := os.WriteFile(filepath.Join(fx.Root, "monoco.yaml"),
+		[]byte("version: 1\nexclude:\n  - modules/private\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(fx.Root, "modules/storage/storage.go"),
+		"package storage\n\nfunc Hello() string { return \"hi\" }\n")
+	runT(t, fx.Root, "git", "add", "-A")
+	runT(t, fx.Root, "git", "commit", "-m", "storage edit")
+
+	out := runCLI(t, bin, fx.Root, "affected", "--since", "HEAD~1")
+	if !strings.Contains(out, "example.com/mono/storage") {
+		t.Errorf("affected missing storage:\n%s", out)
+	}
+	if strings.Contains(out, "example.com/mono/private") {
+		t.Errorf("excluded module appeared in affected:\n%s", out)
+	}
+}
+
+func TestCLI_taskOverrideFromManifest(t *testing.T) {
+	bin := buildCLI(t)
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	// Override `test` with an echo so we don't run real `go test`; the
+	// output must show the marker we supplied.
+	manifest := "version: 1\ntasks:\n  test:\n    command: [\"/bin/echo\", \"MARKER_XYZ\"]\n"
+	if err := os.WriteFile(filepath.Join(fx.Root, "monoco.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := runCLI(t, bin, fx.Root, "test", "--all")
+	if !strings.Contains(out, "MARKER_XYZ") {
+		t.Errorf("task override not applied; output:\n%s", out)
+	}
+}
+
 func buildCLI(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ go 1.25.0
 require golang.org/x/mod v0.35.0
 
 require github.com/pmezard/go-difflib v1.0.0
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,6 @@ golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,144 @@
+// Package config loads the optional monoco.yaml manifest at the repo root.
+//
+// The manifest is convention-over-configuration: in its absence, monoco
+// uses its built-in defaults (every go.mod-bearing dir is a propagatable
+// module; task commands are `go test ./...`, `golangci-lint run`, etc.).
+// The manifest exists so teams with one-off exceptions (an unreleased
+// internal module; a custom lint invocation) can deviate without giving
+// up the defaults elsewhere.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Filename is the manifest filename looked up at the repo root.
+const Filename = "monoco.yaml"
+
+// Config is the parsed manifest. An absent manifest yields a zero-value
+// Config — semantically identical to "no overrides."
+type Config struct {
+	// Version is the manifest schema version. Currently only 1 is valid.
+	Version int `yaml:"version"`
+
+	// Exclude is a list of repo-relative module directories (the same
+	// form that appears in go.work's `use` entries, e.g. `modules/foo`)
+	// that monoco will omit from propagation, affected-set computation,
+	// and task fanout. Forward slashes; cleaned on load.
+	Exclude []string `yaml:"exclude"`
+
+	// Tasks overrides the command executed for a given task name.
+	// Recognized names: test, lint, build, generate. Unknown names are
+	// rejected. Any task name not present keeps its built-in default.
+	Tasks map[string]Task `yaml:"tasks"`
+}
+
+// Task is one task-command override.
+type Task struct {
+	// Command is the argv executed per module. Must be non-empty when a
+	// Task entry is present.
+	Command []string `yaml:"command"`
+}
+
+// knownTasks is the fixed set of task names the CLI dispatches.
+// Keep in sync with cmd/monoco/main.go's switch.
+var knownTasks = map[string]struct{}{
+	"test":     {},
+	"lint":     {},
+	"build":    {},
+	"generate": {},
+}
+
+// Load reads <root>/monoco.yaml. If the file does not exist, it returns
+// a zero-value Config and nil error: absence is not an error.
+// Parse or validation errors are returned as-is.
+func Load(root string) (*Config, error) {
+	path := filepath.Join(root, Filename)
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return &Config{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", Filename, err)
+	}
+	var c Config
+	dec := yaml.NewDecoder(strings.NewReader(string(b)))
+	dec.KnownFields(true)
+	if err := dec.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", Filename, err)
+	}
+	if err := c.validate(); err != nil {
+		return nil, fmt.Errorf("%s: %w", Filename, err)
+	}
+	c.normalize()
+	return &c, nil
+}
+
+// ExcludedSet returns the exclude list as a set of cleaned, slash-form
+// repo-relative directories. Convenient for O(1) lookup at load time.
+func (c *Config) ExcludedSet() map[string]struct{} {
+	out := make(map[string]struct{}, len(c.Exclude))
+	for _, e := range c.Exclude {
+		out[e] = struct{}{}
+	}
+	return out
+}
+
+// TaskCommand returns the configured command for task, or nil if the
+// manifest does not override it. Callers should use their built-in
+// default on nil.
+func (c *Config) TaskCommand(task string) []string {
+	if c == nil {
+		return nil
+	}
+	t, ok := c.Tasks[task]
+	if !ok {
+		return nil
+	}
+	return t.Command
+}
+
+func (c *Config) validate() error {
+	if c.Version != 0 && c.Version != 1 {
+		return fmt.Errorf("version: unsupported value %d (only 1 is recognized)", c.Version)
+	}
+	for i, e := range c.Exclude {
+		if strings.TrimSpace(e) == "" {
+			return fmt.Errorf("exclude[%d]: empty entry", i)
+		}
+		if filepath.IsAbs(e) {
+			return fmt.Errorf("exclude[%d] %q: must be a repo-relative path, not absolute", i, e)
+		}
+		if strings.Contains(e, "..") {
+			return fmt.Errorf("exclude[%d] %q: must not contain `..`", i, e)
+		}
+	}
+	for name, t := range c.Tasks {
+		if _, ok := knownTasks[name]; !ok {
+			return fmt.Errorf("tasks.%s: unknown task (want one of test/lint/build/generate)", name)
+		}
+		if len(t.Command) == 0 {
+			return fmt.Errorf("tasks.%s.command: must have at least one argv element", name)
+		}
+		for j, a := range t.Command {
+			if a == "" {
+				return fmt.Errorf("tasks.%s.command[%d]: empty argv element", name, j)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Config) normalize() {
+	for i, e := range c.Exclude {
+		e = filepath.ToSlash(filepath.Clean(e))
+		e = strings.TrimPrefix(e, "./")
+		c.Exclude[i] = e
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLoad_absent(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load on empty dir: %v", err)
+	}
+	if c == nil {
+		t.Fatal("Load returned nil config on absent manifest")
+	}
+	if len(c.Exclude) != 0 || len(c.Tasks) != 0 {
+		t.Fatalf("absent manifest should yield zero-value config, got %+v", c)
+	}
+	if cmd := c.TaskCommand("test"); cmd != nil {
+		t.Fatalf("TaskCommand on zero config: want nil, got %v", cmd)
+	}
+}
+
+func TestLoad_parsesExcludesAndTasks(t *testing.T) {
+	dir := writeManifest(t, `
+version: 1
+exclude:
+  - modules/internal-experimental
+  - ./modules/private-sdk
+tasks:
+  lint:
+    command: ["golangci-lint", "run", "--timeout=5m"]
+  generate:
+    command: ["go", "generate", "./..."]
+`)
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	wantExclude := []string{"modules/internal-experimental", "modules/private-sdk"}
+	if !reflect.DeepEqual(c.Exclude, wantExclude) {
+		t.Errorf("Exclude: got %v want %v", c.Exclude, wantExclude)
+	}
+	if got := c.TaskCommand("lint"); !reflect.DeepEqual(got, []string{"golangci-lint", "run", "--timeout=5m"}) {
+		t.Errorf("lint command: got %v", got)
+	}
+	if got := c.TaskCommand("test"); got != nil {
+		t.Errorf("unset task should return nil, got %v", got)
+	}
+	set := c.ExcludedSet()
+	if _, ok := set["modules/internal-experimental"]; !ok {
+		t.Errorf("ExcludedSet missing entry: %v", set)
+	}
+}
+
+func TestLoad_rejectsUnknownTask(t *testing.T) {
+	dir := writeManifest(t, `
+version: 1
+tasks:
+  publish:
+    command: ["echo", "hi"]
+`)
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "unknown task") {
+		t.Fatalf("want unknown-task error, got %v", err)
+	}
+}
+
+func TestLoad_rejectsEmptyTaskCommand(t *testing.T) {
+	dir := writeManifest(t, `
+version: 1
+tasks:
+  lint:
+    command: []
+`)
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "at least one argv") {
+		t.Fatalf("want empty-command error, got %v", err)
+	}
+}
+
+func TestLoad_rejectsAbsoluteExclude(t *testing.T) {
+	dir := writeManifest(t, `
+version: 1
+exclude:
+  - /etc/passwd
+`)
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "repo-relative") {
+		t.Fatalf("want abs-path error, got %v", err)
+	}
+}
+
+func TestLoad_rejectsParentExclude(t *testing.T) {
+	dir := writeManifest(t, `
+version: 1
+exclude:
+  - ../outside
+`)
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "..") {
+		t.Fatalf("want parent-ref error, got %v", err)
+	}
+}
+
+func TestLoad_rejectsUnknownFields(t *testing.T) {
+	dir := writeManifest(t, `
+version: 1
+bogus: true
+`)
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "bogus") {
+		t.Fatalf("want unknown-field error, got %v", err)
+	}
+}
+
+func TestLoad_rejectsBadVersion(t *testing.T) {
+	dir := writeManifest(t, `version: 2`)
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "version") {
+		t.Fatalf("want version error, got %v", err)
+	}
+}
+
+func writeManifest(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, Filename), []byte(body), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return dir
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/matt0x6f/monoco/internal/config"
 	"golang.org/x/mod/modfile"
 )
 
@@ -33,7 +34,30 @@ type Workspace struct {
 //
 // Only edges where BOTH endpoints are workspace modules are retained.
 // External dependencies are ignored (they don't participate in propagation).
+//
+// Load also reads the optional <root>/monoco.yaml manifest; any module
+// listed under `exclude` is dropped from the returned workspace as if
+// its go.work entry had never been declared. An absent manifest is not
+// an error.
 func Load(root string) (*Workspace, error) {
+	cfg, err := config.Load(root)
+	if err != nil {
+		return nil, err
+	}
+	return loadWithConfig(root, cfg)
+}
+
+// LoadWithConfig is like Load but takes an already-parsed config. Useful
+// in tests and for callers that need to inspect the manifest separately.
+func LoadWithConfig(root string, cfg *config.Config) (*Workspace, error) {
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	return loadWithConfig(root, cfg)
+}
+
+func loadWithConfig(root string, cfg *config.Config) (*Workspace, error) {
+	excluded := cfg.ExcludedSet()
 	workPath := filepath.Join(root, "go.work")
 	workBytes, err := os.ReadFile(workPath)
 	if err != nil {
@@ -57,6 +81,9 @@ func Load(root string) (*Workspace, error) {
 	var parsedMods []parsed
 
 	for _, u := range wf.Use {
+		if _, skip := excluded[normalizeUsePath(u.Path)]; skip {
+			continue
+		}
 		dir := filepath.Join(root, u.Path)
 		gmBytes, err := os.ReadFile(filepath.Join(dir, "go.mod"))
 		if err != nil {
@@ -85,6 +112,16 @@ func Load(root string) (*Workspace, error) {
 	}
 
 	return ws, nil
+}
+
+// normalizeUsePath converts a go.work `use` entry (e.g. "./modules/foo"
+// or "modules/foo") to the same slash-form the exclude list is normalized
+// to (see config.Config.normalize).
+func normalizeUsePath(p string) string {
+	p = filepath.ToSlash(filepath.Clean(p))
+	// filepath.Clean leaves leading "./" stripped on most platforms, but
+	// be defensive for inputs like "./x" that Clean turns into "x" already.
+	return p
 }
 
 // Consumers returns the set of workspace modules that directly require mod.

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,6 +1,8 @@
 package workspace
 
 import (
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
@@ -57,6 +59,41 @@ func TestLoad_moduleDirResolvable(t *testing.T) {
 	}
 	if m.RelDir == "" {
 		t.Fatal("Module.RelDir empty")
+	}
+}
+
+func TestLoad_honorsMonocoYamlExcludes(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "api", DependsOn: []string{"storage"}},
+			{Name: "private", DependsOn: []string{"storage"}},
+		},
+	})
+
+	// Drop a monoco.yaml that excludes modules/private.
+	manifest := "version: 1\nexclude:\n  - modules/private\n"
+	if err := os.WriteFile(filepath.Join(fx.Root, "monoco.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	ws, err := Load(fx.Root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if _, ok := ws.Modules["example.com/mono/private"]; ok {
+		t.Errorf("excluded module example.com/mono/private still present in workspace")
+	}
+	if _, ok := ws.Modules["example.com/mono/api"]; !ok {
+		t.Errorf("non-excluded module example.com/mono/api missing")
+	}
+	// The excluded consumer shouldn't show up as a reverse-dep of storage.
+	consumers := ws.Consumers("example.com/mono/storage")
+	for _, c := range consumers {
+		if c == "example.com/mono/private" {
+			t.Errorf("excluded module still in reverse-dep edges: %v", consumers)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the optional `monoco.yaml` manifest from issue #1 — the first production-blocker for alpha adoption. Without opt-out, any repo containing one un-releasable module (internal/experimental/private) literally can't run `monoco release`. Absent manifest preserves the current defaults verbatim.

- New `internal/config` package; `KnownFields(true)` so typos like `exludes:` fail loudly.
- `workspace.Load` now reads the manifest and omits excluded modules from the graph — so `affected`, `release`, and task fanout pick it up for free.
- `tasks.<name>.command:` overrides argv for `test` / `lint` / `build` / `generate`; unlisted tasks keep their built-in defaults.
- `monoco init` writes a commented stub manifest (never clobbers an existing one).
- README quickstart + CHANGELOG updated.

Closes #1.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go vet ./...` clean
- [x] `internal/config` unit tests: absent manifest, happy path, unknown key, unknown task, empty command, absolute path, `..`, bad version
- [x] `workspace` test: excluded module + its consumer edge are both absent from the loaded graph
- [x] CLI tests: `init` writes stub (and leaves existing manifest alone); excluded module skipped by `affected`; `tasks.test.command` override actually runs (verified via `/bin/echo` marker)