### PR TITLE
test: lock go.sum and proxy-agreement invariants

### DIFF
--- a/internal/propagate/gosum_test.go
+++ b/internal/propagate/gosum_test.go
@@ -1,0 +1,175 @@
+package propagate
+
+import (
+	"bufio"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"golang.org/x/mod/module"
+	modzip "golang.org/x/mod/zip"
+)
+
+// TestComputeModuleHashes_AgreesWithGoModDownload proves the table-stakes
+// property for drop-in compatibility with any compliant Go module proxy
+// (proxy.golang.org, Athens, JFrog, Nexus, GitLab, ...): the h1: lines
+// monoco precomputes into downstream go.sum files are byte-for-byte what
+// the go toolchain writes when it fetches the same module zip through a
+// proxy.
+//
+// Approach: materialise a filesystem GOPROXY serving the target module,
+// point a fresh consumer module at it, and run `go mod download`. The
+// go.sum Go writes IS the canonical answer. We assert equality with our
+// ComputeModuleHashes output.
+//
+// No network: the proxy is a local directory, GOSUMDB is off. Works in
+// any environment with `go` on PATH.
+func TestComputeModuleHashes_AgreesWithGoModDownload(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file:// GOPROXY URL construction is fiddly on Windows; skip")
+	}
+
+	const (
+		targetPath = "example.test/target"
+		version    = "v1.0.0"
+	)
+
+	// 1. Build the target module on disk.
+	targetDir := t.TempDir()
+	writeGosumTestFile(t, filepath.Join(targetDir, "go.mod"),
+		"module "+targetPath+"\n\ngo 1.22\n")
+	writeGosumTestFile(t, filepath.Join(targetDir, "lib.go"),
+		"package target\n\n// Ping is a stand-in exported symbol.\nfunc Ping() string { return \"pong\" }\n")
+
+	// 2. Ours.
+	ours, err := ComputeModuleHashes(targetDir, targetPath, version)
+	if err != nil {
+		t.Fatalf("ComputeModuleHashes: %v", err)
+	}
+	if !strings.HasPrefix(ours.H1, "h1:") || !strings.HasPrefix(ours.H1Mod, "h1:") {
+		t.Fatalf("expected h1: prefix, got zip=%q mod=%q", ours.H1, ours.H1Mod)
+	}
+
+	// 3. Materialise a filesystem GOPROXY layout:
+	//    $proxy/<module path>/@v/{list, v1.0.0.info, v1.0.0.mod, v1.0.0.zip}
+	proxyDir := t.TempDir()
+	modAtV := filepath.Join(proxyDir, filepath.FromSlash(targetPath), "@v")
+	if err := os.MkdirAll(modAtV, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGosumTestFile(t, filepath.Join(modAtV, "list"), version+"\n")
+	writeGosumTestFile(t, filepath.Join(modAtV, version+".info"),
+		`{"Version":"`+version+`","Time":"2026-01-01T00:00:00Z"}`+"\n")
+	copyFile(t, filepath.Join(targetDir, "go.mod"), filepath.Join(modAtV, version+".mod"))
+
+	zipPath := filepath.Join(modAtV, version+".zip")
+	zf, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := modzip.CreateFromDir(zf, module.Version{Path: targetPath, Version: version}, targetDir); err != nil {
+		zf.Close()
+		t.Fatalf("create proxy zip: %v", err)
+	}
+	if err := zf.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. Consumer module that requires target @ version.
+	consumerDir := t.TempDir()
+	writeGosumTestFile(t, filepath.Join(consumerDir, "go.mod"),
+		"module example.test/consumer\n\ngo 1.22\n\nrequire "+targetPath+" "+version+"\n")
+
+	// 5. `go mod download` through the filesystem proxy. Go writes its
+	// own go.sum based on what it actually downloaded and hashed.
+	proxyURL := (&url.URL{Scheme: "file", Path: filepath.ToSlash(proxyDir)}).String()
+	gopath := t.TempDir()
+
+	// Module cache files are written read-only; t.TempDir cleanup fails
+	// on them. Purge the cache via `go clean -modcache` before Go's
+	// cleanup tries to unlink.
+	t.Cleanup(func() {
+		clean := exec.Command("go", "clean", "-modcache")
+		clean.Env = append(os.Environ(), "GOPATH="+gopath)
+		_ = clean.Run()
+	})
+
+	cmd := exec.Command("go", "mod", "download", targetPath+"@"+version)
+	cmd.Dir = consumerDir
+	cmd.Env = append(os.Environ(),
+		"GOPROXY="+proxyURL,
+		"GOSUMDB=off",
+		"GOFLAGS=-mod=mod",
+		"GOWORK=off",
+		"GOPATH="+gopath,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go mod download: %v\n%s", err, out)
+	}
+
+	// 6. Parse the consumer's go.sum and compare to ours.
+	goH1, goH1Mod := readGoSum(t, filepath.Join(consumerDir, "go.sum"), targetPath, version)
+	if goH1 == "" || goH1Mod == "" {
+		t.Fatalf("go.sum missing entries for %s@%s; got zip=%q mod=%q", targetPath, version, goH1, goH1Mod)
+	}
+
+	if ours.H1 != goH1 {
+		t.Errorf("h1 zip disagreement:\n  ours: %s\n  go:   %s", ours.H1, goH1)
+	}
+	if ours.H1Mod != goH1Mod {
+		t.Errorf("h1 go.mod disagreement:\n  ours: %s\n  go:   %s", ours.H1Mod, goH1Mod)
+	}
+}
+
+// readGoSum returns the zip and go.mod h1: values for modPath@version
+// from a go.sum file. Empty strings if the line is missing.
+func readGoSum(t *testing.T, path, modPath, version string) (h1Zip, h1Mod string) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	zipPrefix := fmt.Sprintf("%s %s ", modPath, version)
+	modPrefix := fmt.Sprintf("%s %s/go.mod ", modPath, version)
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case strings.HasPrefix(line, zipPrefix):
+			h1Zip = strings.TrimPrefix(line, zipPrefix)
+		case strings.HasPrefix(line, modPrefix):
+			h1Mod = strings.TrimPrefix(line, modPrefix)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan %s: %v", path, err)
+	}
+	return
+}
+
+func writeGosumTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	b, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, b, 0o644); err != nil {
+		t.Fatalf("write %s: %v", dst, err)
+	}
+}

--- a/internal/release/gosum_repro_test.go
+++ b/internal/release/gosum_repro_test.go
@@ -1,0 +1,101 @@
+package release
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/matt0x6f/monoco/internal/bump"
+	"github.com/matt0x6f/monoco/internal/fixture"
+	"github.com/matt0x6f/monoco/internal/workspace"
+)
+
+// TestRelease_WithWorkspaceReplace_WritesGoSum reproduces the path
+// exercised by the integration suite: direct-affected detection via a
+// workspace-local `replace` directive, followed by release.Plan +
+// release.Apply. Asserts the downstream go.sum is populated — the
+// property that, in a run against matt0x6F/monoco-test-monorepo on
+// 2026-04-19, silently failed to hold.
+func TestRelease_WithWorkspaceReplace_WritesGoSum(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "api", DependsOn: []string{"storage"}},
+		},
+	})
+	mustGit(t, fx.Root, "tag", "modules/storage/v0.1.0")
+	mustGit(t, fx.Root, "tag", "modules/api/v0.1.0")
+	mustGit(t, fx.Root, "push", "origin", "main", "--tags")
+
+	// Simulate `addLocalReplace`: append a workspace-local replace to
+	// api/go.mod and commit. This is what monoco's release flow looks
+	// for when identifying direct-affected modules.
+	apiModPath := filepath.Join(fx.Root, "modules/api/go.mod")
+	orig, err := os.ReadFile(apiModPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withReplace := append(orig,
+		[]byte("\nreplace example.com/mono/storage => ../storage\n")...)
+	if err := os.WriteFile(apiModPath, withReplace, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, fx.Root, "add", "-A")
+	mustGit(t, fx.Root, "commit", "-m", "local: replace storage for dev")
+
+	// Edit storage so there's a real change to ship.
+	storageSrc := filepath.Join(fx.Root, "modules/storage/storage.go")
+	if err := os.WriteFile(storageSrc,
+		[]byte("package storage\n\nfunc StorageHello() string { return \"new\" }\n"),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, fx.Root, "add", "-A")
+	mustGit(t, fx.Root, "commit", "-m", "storage: change")
+
+	// Run the full release path: Plan + Apply, like the CLI does.
+	ws, err := workspace.Load(fx.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	plan, err := Plan(ws, Options{
+		Slug:  "test",
+		Bumps: map[string]bump.Kind{"example.com/mono/storage": bump.Minor},
+	}, &out)
+	if err != nil {
+		t.Fatalf("Plan: %v\n%s", err, out.String())
+	}
+	if plan == nil {
+		t.Fatalf("plan was nil; stdout:\n%s", out.String())
+	}
+	if _, err := Apply(ws, plan, Options{Remote: "origin"}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// The bug: the published release commit on the real test monorepo
+	// contains no go.sum. Assert that this fixture now does.
+	apiSumPath := filepath.Join(fx.Root, "modules/api/go.sum")
+	sum, err := os.ReadFile(apiSumPath)
+	if err != nil {
+		t.Fatalf("api/go.sum missing after release: %v\n\nplan stdout:\n%s", err, out.String())
+	}
+	s := string(sum)
+	if !strings.Contains(s, "example.com/mono/storage v0.2.0 h1:") {
+		t.Errorf("api/go.sum missing storage h1 zip line:\n%s", s)
+	}
+	if !strings.Contains(s, "example.com/mono/storage v0.2.0/go.mod h1:") {
+		t.Errorf("api/go.sum missing storage go.mod h1 line:\n%s", s)
+	}
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -40,20 +40,25 @@ with `dry_run=true` first if you're uncertain.
 |---|---|
 | `TestFeatEndToEnd` | Flagship: plan → apply → remote tags → external consumer `go get` |
 | `TestNoChangeIsNoOp` | Empty range produces no plan, no push |
-| `TestFixCommitIsPatchBump` | `fix:` → patch bump, cascades as patch |
-| `TestBreakingChangeOnV0` | `feat!:` classified major; v0.x version bump stays within v0 |
+| `TestFixCommitIsPatchBump` | Default patch bump (no `--bump` override); cascades as patch |
+| `TestBreakingChangeOnV0` | `--bump=major` on a v0 module stays within v0 (pre-1.0 rule) |
 | `TestMultiModuleFeat` | Two direct changes + cascade, all tagged on one release commit |
 | `TestVerificationFailureRollsBack` | Broken api.go → apply fails → no tags, no release commit |
-| `TestPlanOnlyDoesNotMutate` | `propagate plan` is read-only |
+| `TestPlanOnlyDoesNotMutate` | `release --dry-run` is read-only |
 
 ## Adding a scenario
 
 1. Create `test/integration/<scenario>_test.go` with `//go:build integration`.
 2. `h := newHarness(t)` — clones, branches, builds the CLI.
 3. Make commits via `h.writeFeat` / `h.writeFix` / `h.writeBreaking` /
-   `h.writeBreakingAPI`.
-4. Call `h.plan()` / `h.apply()` and assert on the stdout plus remote
-   state via `h.assertRemoteHasTag` / `h.assertRemoteMissingTag`.
+   `h.writeBreakingAPI`. The commit-message prefixes are cosmetic —
+   bumps are declared at release time via `--bump <module>=<kind>`, not
+   inferred from commit messages.
+4. Call `h.addLocalReplace(<target>)` to install the workspace-local
+   `replace` directive that marks the target module as direct-affected.
+5. Call `h.plan(...)` / `h.apply(...)` with any `--bump` overrides your
+   scenario needs, and assert on stdout plus remote state via
+   `h.assertRemoteHasTag` / `h.assertRemoteMissingTag`.
 
 Each test's branch and tags are namespaced with a unique `runID`
 (timestamp + 6 hex chars), so scenarios don't collide with each other

--- a/test/integration/feat_e2e_test.go
+++ b/test/integration/feat_e2e_test.go
@@ -53,6 +53,12 @@ func TestFeatEndToEnd(t *testing.T) {
 	h.assertRemoteHasTag("refs/tags/modules/api/" + apiNew)
 	h.assertRemoteHasTag("refs/tags/train/" + todayUTC() + "-" + h.runID)
 
+	// The release commit must also carry api/go.sum — precomputed h1:
+	// lines for the freshly-tagged storage version. Without this, a
+	// consumer building against api@<new> with -mod=readonly fails.
+	h.assertReleaseCommitTouches("api", "go.mod")
+	h.assertReleaseCommitTouches("api", "go.sum")
+
 	// External-consumer probe — the highest-confidence check.
 	h.consumerProbe(apiNew)
 	t.Logf("consumer build succeeded against %s/modules/api@%s", h.modPath, apiNew)

--- a/test/integration/harness.go
+++ b/test/integration/harness.go
@@ -260,6 +260,25 @@ func (h *harness) assertRemoteHasTag(ref string) {
 	}
 }
 
+// assertReleaseCommitTouches fails the test if the local HEAD (which
+// after `apply` is the release commit) does not include a change to
+// modules/<module>/<file>. Use this to lock in that downstream go.sum
+// files actually land in the commit — a regression in the go.sum
+// writing path is otherwise silent: the build still succeeds via the
+// proxy populating go.sum lazily, but offline/readonly consumers
+// break.
+func (h *harness) assertReleaseCommitTouches(module, file string) {
+	h.t.Helper()
+	rel := "modules/" + module + "/" + file
+	out := mustCapture(h.t, h.wt, "git", "show", "--name-only", "--pretty=format:", "HEAD")
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(line) == rel {
+			return
+		}
+	}
+	h.t.Errorf("release commit does not touch %s\nfiles changed:\n%s", rel, out)
+}
+
 // assertRemoteMissingTag fails the test if the given tag ref IS present.
 func (h *harness) assertRemoteMissingTag(ref string) {
 	h.t.Helper()

--- a/test/integration/multi_module_test.go
+++ b/test/integration/multi_module_test.go
@@ -62,4 +62,10 @@ func TestMultiModuleFeat(t *testing.T) {
 	} {
 		h.assertRemoteHasTag(tag)
 	}
+
+	// api consumes storage (and nothing else in the plan), so the
+	// release commit must update api/go.mod and populate api/go.sum
+	// with the precomputed h1: line for storage@<new>.
+	h.assertReleaseCommitTouches("api", "go.mod")
+	h.assertReleaseCommitTouches("api", "go.sum")
 }


### PR DESCRIPTION
## Summary

Adds three layers of test coverage around the invariant that monoco's precomputed `h1:` hashes and the `go.sum` lines we write at release time actually match what a compliant Go module proxy produces.

- **`internal/propagate/gosum_test.go`** — proves `ComputeModuleHashes` is byte-equal to what `go mod download` writes into `go.sum` when fetching through a filesystem GOPROXY serving our zip. This is the table-stakes drop-in-replacement check that covers every compliant proxy (proxy.golang.org, Athens, JFrog, Nexus, GitLab) by transitivity on the `x/mod/zip` + `dirhash.Hash1` spec. Corroborated empirically while writing this PR: monoco's hashes for `storage@v0.2.0` from the integration test monorepo match proxy.golang.org byte-for-byte.
- **`internal/release/gosum_repro_test.go`** — exercises the full `release.Plan` → `release.Apply` path under the workspace-local `replace` + sentinel-`require` shape used by the integration suite. Previously only `propagate.Apply` was covered directly; the release-level path that drops the `replace` and emits `go.sum` lines was not.
- **`test/integration/` — `assertReleaseCommitTouches` helper + assertions in `TestFeatEndToEnd` and `TestMultiModuleFeat`** — locks in that the release commit actually changes downstream `go.mod` *and* `go.sum`. A regression in the go.sum writer is otherwise silent: the proxy happily serves and `-mod=mod` consumers auto-populate, but `-mod=readonly` / offline consumers break against the published tag.

## Why

Auditing pre-alpha readiness raised the question "does the Go module proxy actually agree with what we wrote into `go.sum`?". Investigating turned up a near-miss: the live integration artifact (`eace902` on `matt0x6F/monoco-test-monorepo`) has no `go.sum` at all, because that run happened 4 hours before the go.sum-writing feature merged. The code is correct today, but there was no test pinning it in place from the release orchestrator's side — only from `propagate.Apply`. These tests close that gap.

## Also

Cleans up [test/integration/README.md](test/integration/README.md): the scenario matrix and "adding a scenario" notes still referenced Conventional Commits (`fix:`, `feat!:`) after that classifier was removed in #23. Bumps are declared via `--bump` at release time now.

## Test plan

- [x] `go test ./... -count=1` — green
- [x] `go build -tags=integration ./test/integration/...` — compiles
- [x] New unit tests pass locally (`TestComputeModuleHashes_AgreesWithGoModDownload`, `TestRelease_WithWorkspaceReplace_WritesGoSum`)
- [ ] Next integration run (post-merge) exercises the new assertions against the real monorepo

🤖 Generated with [Claude Code](https://claude.com/claude-code)