### PR TITLE
test(integration): fetch all tags after shallow clone

### DIFF
--- a/test/integration/harness.go
+++ b/test/integration/harness.go
@@ -61,6 +61,15 @@ type harness struct {
 	modPath  string // module-path prefix (e.g. github.com/matt0x6F/monoco-test-monorepo)
 	base     string // merge-base of HEAD with origin/main, set after branch
 	cloneURL string // URL actually used for clone+push (token-baked if HTTPS+TOKEN)
+
+	// baselineTags is a snapshot of refs/tags/* on origin at harness
+	// creation, mapping ref → SHA. Used by assertRemoteMissingTag to
+	// distinguish "this run pushed the tag" (fail) from "a prior run
+	// legitimately left this tag behind" (ignore). Module tags like
+	// modules/storage/v0.2.0 are global and accumulate across runs
+	// until the nightly sweep GCs them, so bare presence/absence is
+	// not a sufficient signal.
+	baselineTags map[string]string
 }
 
 func newHarness(t *testing.T) *harness {
@@ -95,17 +104,39 @@ func newHarness(t *testing.T) *harness {
 	base := trim(mustCapture(t, wt, "git", "merge-base", "HEAD", "origin/main"))
 
 	h := &harness{
-		t:        t,
-		bin:      bin,
-		wt:       wt,
-		runID:    runID,
-		branch:   branch,
-		modPath:  modPath,
-		base:     base,
-		cloneURL: cloneURL,
+		t:            t,
+		bin:          bin,
+		wt:           wt,
+		runID:        runID,
+		branch:       branch,
+		modPath:      modPath,
+		base:         base,
+		cloneURL:     cloneURL,
+		baselineTags: snapshotRemoteTags(t, wt),
 	}
-	t.Logf("harness ready: runID=%s branch=%s base=%s", runID, branch, base[:min(12, len(base))])
+	t.Logf("harness ready: runID=%s branch=%s base=%s baselineTags=%d",
+		runID, branch, base[:min(12, len(base))], len(h.baselineTags))
 	return h
+}
+
+// snapshotRemoteTags returns a map of refs/tags/* → SHA on origin at
+// the moment of the call. Used to detect which tags a test run pushed
+// vs. which already existed (since module tags are globally namespaced
+// and prior runs' tags linger until the nightly sweep GCs them).
+func snapshotRemoteTags(t *testing.T, wt string) map[string]string {
+	t.Helper()
+	out := mustCapture(t, wt, "git", "ls-remote", "--refs", "origin", "refs/tags/*")
+	m := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) == 2 {
+			m[parts[1]] = parts[0]
+		}
+	}
+	return m
 }
 
 // chooseCloneURL returns (url, human-readable note). Prefers HTTPS+token;
@@ -279,13 +310,33 @@ func (h *harness) assertReleaseCommitTouches(module, file string) {
 	h.t.Errorf("release commit does not touch %s\nfiles changed:\n%s", rel, out)
 }
 
-// assertRemoteMissingTag fails the test if the given tag ref IS present.
+// assertRemoteMissingTag fails the test if `ref` was created or moved
+// during this run. A tag that existed at the same SHA when the harness
+// started is treated as pre-existing (from a prior run) and ignored —
+// module tags are a shared namespace and we can only attribute a push
+// to this run when the SHA differs from baseline.
 func (h *harness) assertRemoteMissingTag(ref string) {
 	h.t.Helper()
 	out := mustCapture(h.t, h.wt, "git", "ls-remote", "--refs", "origin", ref)
-	if strings.Contains(out, ref) {
-		h.t.Errorf("remote unexpectedly has %s\nls-remote output:\n%s", ref, out)
+	var sha string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) == 2 && parts[1] == ref {
+			sha = parts[0]
+			break
+		}
 	}
+	if sha == "" {
+		return
+	}
+	if baseline := h.baselineTags[ref]; sha == baseline {
+		return
+	}
+	h.t.Errorf("remote unexpectedly has %s at %s (baseline: %q) — this run pushed or moved the tag\nls-remote output:\n%s",
+		ref, sha, h.baselineTags[ref], out)
 }
 
 // consumerProbe builds a throwaway consumer module in a temp dir and

--- a/test/integration/harness.go
+++ b/test/integration/harness.go
@@ -99,6 +99,13 @@ func newHarness(t *testing.T) *harness {
 	mustRunRetry(t, "", 3, "git", "clone", "--depth", "50", cloneURL, wt)
 	mustRun(t, wt, "git", "config", "user.email", "integration-test@monoco.example")
 	mustRun(t, wt, "git", "config", "user.name", "monoco integration test")
+	// Shallow clone only brings tags reachable from fetched history.
+	// Module tags from prior runs point at per-run commits that aren't
+	// on main, so they'd be invisible locally — causing monoco to plan
+	// a bump onto a version that already exists remotely and then get
+	// rejected by atomic push. Fetch all tags explicitly so the local
+	// tag state matches the remote's public API.
+	mustRunRetry(t, wt, 3, "git", "fetch", "--tags", "origin")
 	mustRun(t, wt, "git", "checkout", "-b", branch)
 
 	base := trim(mustCapture(t, wt, "git", "merge-base", "HEAD", "origin/main"))


### PR DESCRIPTION
## Summary

Follow-up to #28. The first post-merge integration run ([run 24695886666](https://github.com/matt0x6F/monoco/actions/runs/24695886666)) confirmed `TestVerificationFailureRollsBack` now passes, but surfaced a second harness issue: `TestMultiModuleFeat` failed with atomic push rejecting `modules/storage/v0.2.0` because that tag already existed on origin.

The harness clones with `--depth 50`, which only fetches tags reachable from the 50-commit history of `main`. Module tags from prior runs point at per-run commits that aren't reachable from main, so they were invisible locally. Monoco plans bumps from local tag state, so it proposed `storage v0.1.0 → v0.2.0` while `v0.2.0` already existed remotely — and atomic push rejected the release.

This change does `git fetch --tags origin` after the shallow clone so the local tag state matches the remote's public API. Monoco's planner then sees the real high-water mark.

## Why not fix in monoco itself?

Arguably monoco should also consult remote tags pre-plan as a correctness check, but that's a separate design call (adds a network call to `plan`; raises questions about what "baseline" means when a concurrent release pushed a conflicting tag). For now, making the harness honest about remote state matches the scope of #28 — both changes are "make the test harness's assumptions about the shared tag namespace match reality."

## Test plan

- [x] `go vet -tags=integration ./test/integration/...` clean
- [x] `go build -tags=integration ./test/integration/...` builds
- [ ] Post-merge integration run passes `TestMultiModuleFeat` and `TestFeatEndToEnd` against the accumulated remote tag state