### PR TITLE
test(integration): chmod consumer HOME before TempDir cleanup

### DIFF
--- a/test/integration/harness.go
+++ b/test/integration/harness.go
@@ -61,6 +61,15 @@ type harness struct {
 	modPath  string // module-path prefix (e.g. github.com/matt0x6F/monoco-test-monorepo)
 	base     string // merge-base of HEAD with origin/main, set after branch
 	cloneURL string // URL actually used for clone+push (token-baked if HTTPS+TOKEN)
+
+	// baselineTags is a snapshot of refs/tags/* on origin at harness
+	// creation, mapping ref → SHA. Used by assertRemoteMissingTag to
+	// distinguish "this run pushed the tag" (fail) from "a prior run
+	// legitimately left this tag behind" (ignore). Module tags like
+	// modules/storage/v0.2.0 are global and accumulate across runs
+	// until the nightly sweep GCs them, so bare presence/absence is
+	// not a sufficient signal.
+	baselineTags map[string]string
 }
 
 func newHarness(t *testing.T) *harness {
@@ -95,17 +104,39 @@ func newHarness(t *testing.T) *harness {
 	base := trim(mustCapture(t, wt, "git", "merge-base", "HEAD", "origin/main"))
 
 	h := &harness{
-		t:        t,
-		bin:      bin,
-		wt:       wt,
-		runID:    runID,
-		branch:   branch,
-		modPath:  modPath,
-		base:     base,
-		cloneURL: cloneURL,
+		t:            t,
+		bin:          bin,
+		wt:           wt,
+		runID:        runID,
+		branch:       branch,
+		modPath:      modPath,
+		base:         base,
+		cloneURL:     cloneURL,
+		baselineTags: snapshotRemoteTags(t, wt),
 	}
-	t.Logf("harness ready: runID=%s branch=%s base=%s", runID, branch, base[:min(12, len(base))])
+	t.Logf("harness ready: runID=%s branch=%s base=%s baselineTags=%d",
+		runID, branch, base[:min(12, len(base))], len(h.baselineTags))
 	return h
+}
+
+// snapshotRemoteTags returns a map of refs/tags/* → SHA on origin at
+// the moment of the call. Used to detect which tags a test run pushed
+// vs. which already existed (since module tags are globally namespaced
+// and prior runs' tags linger until the nightly sweep GCs them).
+func snapshotRemoteTags(t *testing.T, wt string) map[string]string {
+	t.Helper()
+	out := mustCapture(t, wt, "git", "ls-remote", "--refs", "origin", "refs/tags/*")
+	m := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) == 2 {
+			m[parts[1]] = parts[0]
+		}
+	}
+	return m
 }
 
 // chooseCloneURL returns (url, human-readable note). Prefers HTTPS+token;
@@ -279,13 +310,33 @@ func (h *harness) assertReleaseCommitTouches(module, file string) {
 	h.t.Errorf("release commit does not touch %s\nfiles changed:\n%s", rel, out)
 }
 
-// assertRemoteMissingTag fails the test if the given tag ref IS present.
+// assertRemoteMissingTag fails the test if `ref` was created or moved
+// during this run. A tag that existed at the same SHA when the harness
+// started is treated as pre-existing (from a prior run) and ignored —
+// module tags are a shared namespace and we can only attribute a push
+// to this run when the SHA differs from baseline.
 func (h *harness) assertRemoteMissingTag(ref string) {
 	h.t.Helper()
 	out := mustCapture(h.t, h.wt, "git", "ls-remote", "--refs", "origin", ref)
-	if strings.Contains(out, ref) {
-		h.t.Errorf("remote unexpectedly has %s\nls-remote output:\n%s", ref, out)
+	var sha string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) == 2 && parts[1] == ref {
+			sha = parts[0]
+			break
+		}
 	}
+	if sha == "" {
+		return
+	}
+	if baseline := h.baselineTags[ref]; sha == baseline {
+		return
+	}
+	h.t.Errorf("remote unexpectedly has %s at %s (baseline: %q) — this run pushed or moved the tag\nls-remote output:\n%s",
+		ref, sha, h.baselineTags[ref], out)
 }
 
 // consumerProbe builds a throwaway consumer module in a temp dir and

--- a/test/integration/harness.go
+++ b/test/integration/harness.go
@@ -355,6 +355,22 @@ func (h *harness) consumerProbe(apiVersion string) {
 	consumerDir := h.t.TempDir()
 	consumerHome := h.t.TempDir() // sandboxed HOME for .netrc
 
+	// Go populates $GOMODCACHE (default $HOME/go/pkg/mod) with files
+	// mode 0444 so module contents are immutable. t.TempDir's cleanup
+	// RemoveAll doesn't chmod before unlinking, so teardown would fail
+	// with "permission denied." Register a LIFO-earlier cleanup that
+	// walks the dir and restores write perms. (t.Cleanup fires before
+	// the RemoveAll registered by TempDir at creation.)
+	h.t.Cleanup(func() {
+		_ = filepath.Walk(consumerHome, func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil
+			}
+			_ = os.Chmod(p, 0o700)
+			return nil
+		})
+	})
+
 	consumerGoMod := "module monoco-integration-consumer\n\ngo 1.22\n"
 	consumerMain := "package main\n\nimport (\n\t\"fmt\"\n\n\t\"" +
 		h.modPath + "/modules/api\"\n)\n\nfunc main() {\n\tfmt.Println(api.Fetch(\"probe\"))\n}\n"

--- a/test/integration/harness.go
+++ b/test/integration/harness.go
@@ -99,6 +99,13 @@ func newHarness(t *testing.T) *harness {
 	mustRunRetry(t, "", 3, "git", "clone", "--depth", "50", cloneURL, wt)
 	mustRun(t, wt, "git", "config", "user.email", "integration-test@monoco.example")
 	mustRun(t, wt, "git", "config", "user.name", "monoco integration test")
+	// Shallow clone only brings tags reachable from fetched history.
+	// Module tags from prior runs point at per-run commits that aren't
+	// on main, so they'd be invisible locally — causing monoco to plan
+	// a bump onto a version that already exists remotely and then get
+	// rejected by atomic push. Fetch all tags explicitly so the local
+	// tag state matches the remote's public API.
+	mustRunRetry(t, wt, 3, "git", "fetch", "--tags", "origin")
 	mustRun(t, wt, "git", "checkout", "-b", branch)
 
 	base := trim(mustCapture(t, wt, "git", "merge-base", "HEAD", "origin/main"))


### PR DESCRIPTION
## Summary

Follow-up to #28 and #29. Integration [run 24695969032](https://github.com/matt0x6F/monoco/actions/runs/24695969032) went from 2 failures to 1: `TestMultiModuleFeat` and `TestVerificationFailureRollsBack` are green. The one remaining failure is `TestFeatEndToEnd`, and the test itself actually passes — the consumer build succeeded against the freshly-pushed `modules/api@v0.1.3`. What fails is `t.TempDir`'s cleanup:

```
TempDir RemoveAll cleanup: unlinkat /tmp/.../go/pkg/mod/.../storage@v0.4.0/storage_test.go: permission denied
```

`go get` populates `$GOMODCACHE` (defaulted here to the sandboxed `$HOME/go/pkg/mod`) with files at mode `0444` — module-cache immutability is deliberate and is what makes builds reproducible. `t.TempDir`'s cleanup calls `RemoveAll`, which doesn't chmod before unlinking, so teardown fails.

## Fix

Register a `t.Cleanup` right after the `consumerHome` `TempDir` call that walks the tree and restores write perms. Cleanups run LIFO, so this fires before the `RemoveAll` that `TempDir` registered at creation.

## Test plan

- [x] `go vet -tags=integration ./test/integration/...` clean
- [x] `go build -tags=integration ./test/integration/...` builds
- [ ] Post-merge integration run on main — all 7 scenarios green end-to-end, no cleanup errors