### PR TITLE
release: guard apply against concurrent base moves (#7)

### DIFF
--- a/cmd/monoco/commands.go
+++ b/cmd/monoco/commands.go
@@ -64,7 +64,12 @@ func cmdRelease(root string, args []string) {
 		AllowMajor: allowMajorSet,
 	}
 
-	plan, err := release.Plan(ws, opts, os.Stdout)
+	// Dry-run is offline: don't ls-remote for a base SHA we won't use.
+	planOpts := opts
+	if *dryRun {
+		planOpts.Remote = ""
+	}
+	plan, err := release.Plan(ws, planOpts, os.Stdout)
 	if err != nil {
 		fatal(err)
 	}

--- a/internal/propagate/apply.go
+++ b/internal/propagate/apply.go
@@ -41,6 +41,20 @@ func Apply(ws *workspace.Workspace, plan *Plan, opts ApplyOptions) (*ApplyResult
 		return nil, err
 	}
 
+	// Preflight: if the plan recorded a remote base SHA, re-check that
+	// the remote hasn't advanced. This is the cheap path that aborts
+	// BEFORE any rewrite/verify work; the lease on push (step 5) closes
+	// the residual TOCTOU window.
+	if plan.BaseSHA != "" && opts.Remote != "" {
+		cur, err := GetRemoteRefSHA(ws.Root, opts.Remote, plan.BaseRef)
+		if err != nil {
+			return nil, fmt.Errorf("recheck %s %s: %w", opts.Remote, plan.BaseRef, err)
+		}
+		if cur != plan.BaseSHA {
+			return nil, fmt.Errorf("base moved: %s %s was %s when plan was computed, now %s; re-run 'monoco propagate plan' and retry", opts.Remote, plan.BaseRef, plan.BaseSHA, cur)
+		}
+	}
+
 	// Snapshot HEAD for rollback.
 	oldHeadOut, err := shellGit(ws.Root, "rev-parse", "HEAD")
 	if err != nil {
@@ -131,7 +145,7 @@ func Apply(ws *workspace.Workspace, plan *Plan, opts ApplyOptions) (*ApplyResult
 			return result, fmt.Errorf("detect branch: %w", err)
 		}
 	}
-	if err := atomicPush(ws.Root, opts.Remote, branch, createdTags); err != nil {
+	if err := atomicPush(ws.Root, opts.Remote, branch, createdTags, plan.BaseSHA); err != nil {
 		return result, fmt.Errorf("atomic push: %w", err)
 	}
 	result.Pushed = true
@@ -411,13 +425,57 @@ func requireCleanWorkingTree(root string) error {
 	return nil
 }
 
-func atomicPush(root, remote, branch string, tags []string) error {
-	args := []string{"push", "--atomic", remote, branch}
-	for _, t := range tags {
-		args = append(args, "refs/tags/"+t)
+func atomicPush(root, remote, branch string, tags []string, leaseSHA string) error {
+	build := func(withLease bool) []string {
+		args := []string{"push", "--atomic"}
+		if withLease && leaseSHA != "" {
+			args = append(args, "--force-with-lease="+branch+":"+leaseSHA)
+		}
+		args = append(args, remote, branch)
+		for _, t := range tags {
+			args = append(args, "refs/tags/"+t)
+		}
+		return args
 	}
-	_, err := shellGit(root, args...)
-	return err
+
+	if leaseSHA == "" {
+		_, err := shellGit(root, build(false)...)
+		return err
+	}
+
+	// Try with lease first. If the remote's branch-protection config
+	// rejects force-style pushes even when the lease holds, fall back
+	// to a plain atomic push: a non-fast-forward would still be
+	// rejected, and the preflight SHA check already caught the common
+	// race. The fallback keeps monoco usable on strict GitHub orgs.
+	_, err := shellGit(root, build(true)...)
+	if err == nil {
+		return nil
+	}
+	if !isProtectedBranchLeaseReject(err) {
+		return err
+	}
+	_, err2 := shellGit(root, build(false)...)
+	return err2
+}
+
+// isProtectedBranchLeaseReject reports whether a push failure looks
+// like a protected-branch rule blocking force-with-lease. We retry
+// without the lease in that case.
+func isProtectedBranchLeaseReject(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "protected branch hook declined"):
+		return true
+	case strings.Contains(msg, "cannot force-push to this protected branch"):
+		return true
+	case strings.Contains(msg, "force pushes are not allowed"):
+		return true
+	}
+	return false
 }
 
 func tagAlreadyAt(root, tag, sha string) bool {

--- a/internal/propagate/apply_test.go
+++ b/internal/propagate/apply_test.go
@@ -233,6 +233,86 @@ func TestApply_bootstrapFromPlaceholders(t *testing.T) {
 	}
 }
 
+func TestApply_ConcurrentBaseMove(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "api", DependsOn: []string{"storage"}},
+		},
+	})
+	run(t, fx.Root, "git", "tag", "modules/storage/v0.1.0")
+	run(t, fx.Root, "git", "tag", "modules/api/v0.1.0")
+	run(t, fx.Root, "git", "push", "origin", "main", "--tags")
+
+	// Apply a storage change (simulates in-progress dev).
+	writeFile(t, filepath.Join(fx.Root, "modules/storage/storage.go"),
+		"package storage\n\nfunc StorageHello() string { return \"new\" }\nfunc Batch() string { return \"batch\" }\n")
+	run(t, fx.Root, "git", "add", "-A")
+	run(t, fx.Root, "git", "commit", "-m", "storage: add Batch")
+
+	// Capture the remote base SHA exactly as release.Plan would.
+	baseSHA, err := GetRemoteRefSHA(fx.Root, "origin", "refs/heads/main")
+	if err != nil {
+		t.Fatalf("GetRemoteRefSHA: %v", err)
+	}
+
+	ws, _ := workspace.Load(fx.Root)
+	plan, err := NewPlanForModules(ws, []string{"example.com/mono/storage"}, Options{
+		Slug:    "race",
+		Bumps:   map[string]bump.Kind{"example.com/mono/storage": bump.Minor},
+		BaseRef: "refs/heads/main",
+		BaseSHA: baseSHA,
+	})
+	if err != nil {
+		t.Fatalf("NewPlanForModules: %v", err)
+	}
+
+	// Simulate a competing run: clone the bare remote, push an
+	// unrelated commit, which advances origin/main between plan and
+	// apply.
+	advanceRemoteMain(t, fx.RemoteDir)
+
+	_, err = Apply(ws, plan, ApplyOptions{Remote: "origin"})
+	if err == nil {
+		t.Fatal("Apply should have failed due to base SHA drift")
+	}
+	if !strings.Contains(err.Error(), "base moved") {
+		t.Fatalf("expected base-moved error, got: %v", err)
+	}
+
+	// No local tags should have been created for this run.
+	for _, tg := range []string{
+		"modules/storage/v0.2.0",
+		"modules/api/v0.1.1",
+		plan.TrainTag,
+	} {
+		if tagExists(t, fx.Root, tg) {
+			t.Errorf("tag %s should not exist after aborted apply", tg)
+		}
+	}
+	// No release commit either.
+	if n := countCommitsSince(t, fx.Root, baseSHA); n != 1 {
+		t.Errorf("expected 1 commit since base (the storage feat), got %d", n)
+	}
+}
+
+// advanceRemoteMain pushes an unrelated commit to the bare remote's
+// main branch from a fresh clone.
+func advanceRemoteMain(t *testing.T, remoteDir string) {
+	t.Helper()
+	other := t.TempDir()
+	run(t, other, "git", "clone", remoteDir, ".")
+	// Ensure a local `main` tracking origin/main exists regardless of
+	// the clone's HEAD handling across git versions.
+	run(t, other, "git", "checkout", "-B", "main", "origin/main")
+	run(t, other, "git", "config", "user.email", "concurrent@example.com")
+	run(t, other, "git", "config", "user.name", "Concurrent")
+	writeFile(t, filepath.Join(other, "concurrent.txt"), "raced\n")
+	run(t, other, "git", "add", "-A")
+	run(t, other, "git", "commit", "-m", "concurrent: race")
+	run(t, other, "git", "push", "origin", "main")
+}
+
 func TestApply_refusesDirtyWorkingTree(t *testing.T) {
 	fx := fixture.New(t, fixture.Spec{
 		Modules: []fixture.ModuleSpec{{Name: "storage"}},

--- a/internal/propagate/plan.go
+++ b/internal/propagate/plan.go
@@ -34,6 +34,12 @@ type Options struct {
 	// path (the form in go.mod's `module` line, without any `/vN`
 	// suffix). At most one module per plan may cross; see buildPlan.
 	AllowMajor map[string]struct{}
+	// BaseRef is the remote ref the plan's commit will be pushed to
+	// (e.g. "refs/heads/main"). Empty when no push is intended.
+	BaseRef string
+	// BaseSHA is the SHA of BaseRef on the remote at plan time. Used by
+	// Apply to detect concurrent pushes. Empty when BaseRef is empty.
+	BaseSHA string
 }
 
 // Entry is one module's slice of a plan.
@@ -54,6 +60,13 @@ type Plan struct {
 	Entries   []Entry
 	TrainTag  string // train/<YYYY-MM-DD>-<slug>
 	CommitMsg string // "release: <TrainTag>"
+	// BaseRef is the remote ref the release will push to (e.g.
+	// "refs/heads/main"). Empty when no push is intended.
+	BaseRef string
+	// BaseSHA is the SHA of BaseRef on the remote captured at plan time.
+	// Apply re-checks this before any mutation to detect concurrent
+	// pushes; empty disables the check.
+	BaseSHA string
 }
 
 // NewPlanForModules computes a plan from an explicit directly-affected
@@ -241,6 +254,8 @@ func buildPlan(ws *workspace.Workspace, modules []string, directSet map[string]s
 		Entries:   entries,
 		TrainTag:  train,
 		CommitMsg: "release: " + train,
+		BaseRef:   opts.BaseRef,
+		BaseSHA:   opts.BaseSHA,
 	}, nil
 }
 
@@ -328,12 +343,41 @@ func topoOrder(ws *workspace.Workspace, modules []string) []string {
 	return out
 }
 
+// CurrentBranch returns the short name of the branch currently checked
+// out at root (e.g. "main"). Errors if HEAD is detached.
+func CurrentBranch(root string) (string, error) {
+	return currentBranch(root)
+}
+
 func currentBranch(root string) (string, error) {
 	out, err := shellGit(root, "symbolic-ref", "--short", "HEAD")
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(out), nil
+}
+
+// GetRemoteRefSHA returns the SHA of ref on remote via `git ls-remote`.
+// ref is a full ref (e.g. "refs/heads/main"). Returns an error if the
+// remote has no such ref.
+func GetRemoteRefSHA(root, remote, ref string) (string, error) {
+	out, err := shellGit(root, "ls-remote", remote, ref)
+	if err != nil {
+		return "", err
+	}
+	line := strings.TrimSpace(out)
+	if line == "" {
+		return "", fmt.Errorf("remote %q has no ref %q", remote, ref)
+	}
+	// First line, first column.
+	if nl := strings.IndexByte(line, '\n'); nl >= 0 {
+		line = line[:nl]
+	}
+	tab := strings.IndexAny(line, " \t")
+	if tab < 0 {
+		return "", fmt.Errorf("unexpected ls-remote output: %q", line)
+	}
+	return strings.TrimSpace(line[:tab]), nil
 }
 
 func sanitizeSlug(s string) string {

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -31,6 +31,8 @@ type Options struct {
 	// version boundary in this release. Typically unioned from the
 	// --allow-major CLI flag and monoco.yaml's allow_major entries.
 	AllowMajor map[string]struct{}
+	// Branch overrides the branch to push to; defaults to current.
+	Branch string
 }
 
 // Plan gathers affected modules, applies bump kinds (default patch,
@@ -57,11 +59,31 @@ func Plan(ws *workspace.Workspace, opts Options, stdout io.Writer) (*propagate.P
 		}
 	}
 
-	plan, err := propagate.NewPlanForModules(ws, directs, propagate.Options{
+	popts := propagate.Options{
 		Slug:       opts.Slug,
 		Bumps:      bumps,
 		AllowMajor: opts.AllowMajor,
-	})
+	}
+	// Capture the remote branch SHA so Apply can detect concurrent
+	// pushes. Only meaningful when we intend to push.
+	if opts.Remote != "" {
+		branch := opts.Branch
+		if branch == "" {
+			branch, err = propagate.CurrentBranch(ws.Root)
+			if err != nil {
+				return nil, fmt.Errorf("detect branch: %w", err)
+			}
+		}
+		ref := "refs/heads/" + branch
+		sha, err := propagate.GetRemoteRefSHA(ws.Root, opts.Remote, ref)
+		if err != nil {
+			return nil, fmt.Errorf("read %s %s: %w", opts.Remote, ref, err)
+		}
+		popts.BaseRef = ref
+		popts.BaseSHA = sha
+	}
+
+	plan, err := propagate.NewPlanForModules(ws, directs, popts)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +98,10 @@ func Plan(ws *workspace.Workspace, opts Options, stdout io.Writer) (*propagate.P
 // Apply executes the plan. Thin wrapper around propagate.Apply so the
 // CLI only imports `release`.
 func Apply(ws *workspace.Workspace, plan *propagate.Plan, opts Options) (*propagate.ApplyResult, error) {
-	return propagate.Apply(ws, plan, propagate.ApplyOptions{Remote: opts.Remote})
+	return propagate.Apply(ws, plan, propagate.ApplyOptions{
+		Remote: opts.Remote,
+		Branch: opts.Branch,
+	})
 }
 
 // CurrentVersions reports the latest tagged version per module path.


### PR DESCRIPTION
## Summary
- Capture `origin/<branch>` SHA at plan time (`propagate.Plan.BaseSHA`) and re-check it at the start of `Apply`, aborting cleanly *before* any rewrite/verify/commit work when the remote has moved.
- Push now uses `--force-with-lease=<branch>:<baseSHA>` so a race that slips past the pre-check still can't overwrite a concurrent push. The lease doesn't rewrite history — when it holds, the push is a normal fast-forward.
- Fallback: if the lease is rejected by a protected-branch rule (`protected branch hook declined`, etc.), retry once without the lease. The pre-check plus git's own non-ff rejection still cover the race in that case.
- `monoco release --dry-run` skips the `ls-remote` so previews stay offline.

Closes #7.

## Why
Between `release.Plan` and `release.Apply` there's an interactive confirmation (plus, in CI, potential minutes of lag). Today nothing detects that `origin/<branch>` has advanced in that window — the second run wastes a full verify cycle and, if retried naively, can land module tags that point at a commit which is not an ancestor of `main`. Shipping a GitHub Action (#9) makes this race more likely, so it's an alpha blocker.

## Design notes
- `git ls-remote` (not `git fetch`) reads the remote ref without mutating local state — the right primitive for a plan-time snapshot.
- Two complementary checks: the cheap ls-remote check fails fast; the lease closes the residual TOCTOU window between check and push.
- Protected-branch fallback is silent-by-default so strict GitHub orgs aren't blocked from adoption. Alternative considered: a `--lease` flag; decided against — the pre-check plus natural non-ff rejection is already sufficient.

## Test plan
- [x] New unit test `TestApply_ConcurrentBaseMove` simulates a concurrent push by cloning the bare remote in a second working tree and pushing back between `Plan` and `Apply`. Asserts the "base moved" error, no local tags, no extra release commit.
- [x] `go test ./...` — full suite passes.
- [x] `go vet ./...` — clean.
- [ ] Manual smoke test against the integration fixture (reviewer welcome to pull and try).