### PR TITLE
test: cover bootstrap-from-placeholders propagation

### DIFF
--- a/internal/propagate/apply_test.go
+++ b/internal/propagate/apply_test.go
@@ -136,6 +136,103 @@ func TestApply_rollsBackOnVerifyFailure(t *testing.T) {
 	}
 }
 
+func TestApply_bootstrapFromPlaceholders(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "api", DependsOn: []string{"storage"}},
+		},
+	})
+	// No pre-seeded tags: this is the first-ever propagation.
+	run(t, fx.Root, "git", "push", "origin", "main")
+
+	const placeholder = "v0.0.0-00010101000000-000000000000"
+	apiModPath := filepath.Join(fx.Root, "modules/api/go.mod")
+	preApiMod, err := os.ReadFile(apiModPath)
+	if err != nil {
+		t.Fatalf("read api/go.mod: %v", err)
+	}
+	if !strings.Contains(string(preApiMod), placeholder) {
+		t.Fatalf("fixture should seed placeholder pseudo-version; api/go.mod:\n%s", preApiMod)
+	}
+
+	base := headSHA(t, fx.Root)
+
+	writeFile(t, filepath.Join(fx.Root, "modules/storage/storage.go"),
+		"package storage\n\nfunc StorageHello() string { return \"new\" }\nfunc Batch() string { return \"batch\" }\n")
+	run(t, fx.Root, "git", "add", "-A")
+	run(t, fx.Root, "git", "commit", "-m", "storage: add Batch")
+
+	ws, _ := workspace.Load(fx.Root)
+	plan, err := NewPlanForModules(ws, []string{"example.com/mono/storage"}, Options{
+		Slug:  "bootstrap",
+		Bumps: map[string]bump.Kind{"example.com/mono/storage": bump.Minor},
+	})
+	if err != nil {
+		t.Fatalf("NewPlanForModules: %v", err)
+	}
+
+	res, err := Apply(ws, plan, ApplyOptions{Remote: "origin"})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if got := countCommitsSince(t, fx.Root, base); got != 2 {
+		t.Errorf("expected 2 commits after base (feat + release); got %d", got)
+	}
+
+	apiMod, _ := os.ReadFile(apiModPath)
+	if strings.Contains(string(apiMod), placeholder) {
+		t.Errorf("api/go.mod still contains placeholder after apply:\n%s", apiMod)
+	}
+	if !strings.Contains(string(apiMod), "example.com/mono/storage v0.1.0") {
+		t.Errorf("api/go.mod not rewritten to storage v0.1.0:\n%s", apiMod)
+	}
+
+	apiSum, err := os.ReadFile(filepath.Join(fx.Root, "modules/api/go.sum"))
+	if err != nil {
+		t.Fatalf("read api/go.sum: %v", err)
+	}
+	if !strings.Contains(string(apiSum), "example.com/mono/storage v0.1.0 h1:") {
+		t.Errorf("api/go.sum missing storage h1 line:\n%s", apiSum)
+	}
+	if !strings.Contains(string(apiSum), "example.com/mono/storage v0.1.0/go.mod h1:") {
+		t.Errorf("api/go.sum missing storage go.mod h1 line:\n%s", apiSum)
+	}
+
+	for _, expected := range []string{
+		"modules/storage/v0.1.0",
+		"modules/api/v0.1.0",
+		plan.TrainTag,
+	} {
+		if !tagExists(t, fx.Root, expected) {
+			t.Errorf("missing local tag %s", expected)
+		}
+	}
+
+	releaseSHA := res.ReleaseCommit
+	for _, tg := range []string{
+		"modules/storage/v0.1.0",
+		"modules/api/v0.1.0",
+		plan.TrainTag,
+	} {
+		if got := tagSHA(t, fx.Root, tg); got != releaseSHA {
+			t.Errorf("tag %s points at %s, not release commit %s", tg, got, releaseSHA)
+		}
+	}
+
+	remoteTags := remoteTagList(t, fx.RemoteDir)
+	for _, expected := range []string{
+		"modules/storage/v0.1.0",
+		"modules/api/v0.1.0",
+		plan.TrainTag,
+	} {
+		if !sliceContains(remoteTags, expected) {
+			t.Errorf("remote missing %s; has %v", expected, remoteTags)
+		}
+	}
+}
+
 func TestApply_refusesDirtyWorkingTree(t *testing.T) {
 	fx := fixture.New(t, fixture.Spec{
 		Modules: []fixture.ModuleSpec{{Name: "storage"}},

--- a/test/integration/bootstrap_e2e_test.go
+++ b/test/integration/bootstrap_e2e_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBootstrapFirstEverTag covers the "first-ever release for a module
+// that has never been tagged" path against the real remote. The shared
+// test repo is pre-seeded with tagged modules, so we simulate bootstrap
+// by adding a brand-new module on the per-run branch and releasing it:
+// `NextVersion("", ...)` must produce v0.1.0, and that tag must land on
+// origin atomically with the train tag.
+//
+// Placeholder-pseudo-version rewriting is exhaustively covered by the
+// unit test TestApply_bootstrapFromPlaceholders; this integration test
+// focuses on the end-to-end first-tag landing.
+func TestBootstrapFirstEverTag(t *testing.T) {
+	h := newHarness(t)
+
+	modSuffix := "bootstrap" + strings.ReplaceAll(strings.ReplaceAll(h.runID, "-", ""), "T", "")
+	moduleDir := "modules/" + modSuffix
+	modulePath := h.modPath + "/" + moduleDir
+
+	h.addFreshModule(modSuffix, modulePath)
+	// A feat commit on the new module makes it direct-affected.
+	h.writeFeat(modSuffix, "Bootstrap")
+
+	planOut := h.plan("--bump", moduleDir+"=minor")
+	t.Logf("plan:\n%s", planOut)
+
+	_, newV, kind, direct := findPlanEntry(t, planOut, modulePath)
+	if newV != "v0.1.0" {
+		t.Errorf("new version: want v0.1.0, got %s", newV)
+	}
+	if kind != "minor" {
+		t.Errorf("kind: want minor, got %s", kind)
+	}
+	if direct != "direct" {
+		t.Errorf("direct column: want direct, got %s", direct)
+	}
+
+	applyOut := h.apply("--bump", moduleDir+"=minor")
+	t.Logf("apply:\n%s", applyOut)
+	if !strings.Contains(applyOut, "Pushed to origin") {
+		t.Fatalf("apply did not push:\n%s", applyOut)
+	}
+
+	tag := "refs/tags/" + moduleDir + "/v0.1.0"
+	h.assertRemoteHasTag(tag)
+	h.assertRemoteHasTag("refs/tags/train/" + todayUTC() + "-" + h.runID)
+
+	// Confirm this is the first time this tag exists — not a re-push of
+	// something baselined by newHarness.
+	if _, was := h.baselineTags[tag]; was {
+		t.Errorf("tag %s existed at baseline; test is not exercising the bootstrap path", tag)
+	}
+}
+
+// addFreshModule creates a brand-new module directory with a minimal
+// go.mod and one .go source file, wires it into go.work via `use`, and
+// commits. The module has no prior tag on origin, so the next release
+// must bootstrap it at v0.1.0.
+func (h *harness) addFreshModule(name, fullModulePath string) {
+	h.t.Helper()
+	dir := filepath.Join(h.wt, "modules", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		h.t.Fatalf("mkdir %s: %v", dir, err)
+	}
+
+	goMod := fmt.Sprintf("module %s\n\ngo 1.22\n", fullModulePath)
+	mustWrite(h.t, filepath.Join(dir, "go.mod"), goMod)
+
+	// Source file — package name must be a valid identifier; the module
+	// directory name includes hex/timestamp characters, so we use a
+	// stable package name and let the import path carry the uniqueness.
+	src := "package bootstrap\n\n// Marker keeps the module non-empty.\nfunc Marker() string { return \"bootstrap\" }\n"
+	mustWrite(h.t, filepath.Join(dir, name+".go"), src)
+
+	// Append a `use` line to go.work. The test repo's go.work already
+	// registers the pre-seeded modules; we only add our new one.
+	workPath := filepath.Join(h.wt, "go.work")
+	existing, err := os.ReadFile(workPath)
+	if err != nil {
+		h.t.Fatalf("read go.work: %v", err)
+	}
+	useLine := fmt.Sprintf("\nuse ./modules/%s\n", name)
+	if err := os.WriteFile(workPath, append(existing, []byte(useLine)...), 0o644); err != nil {
+		h.t.Fatalf("write go.work: %v", err)
+	}
+
+	mustRun(h.t, h.wt, "git", "add", "-A")
+	mustRun(h.t, h.wt, "git", "commit", "-m", "bootstrap: add fresh module "+name+" for run "+h.runID)
+}


### PR DESCRIPTION
## Summary

Closes #18. Adds explicit end-to-end coverage for the "first-ever release" path — a brand-new monorepo whose cross-module `require` entries carry the placeholder pseudo-version `v0.0.0-00010101000000-000000000000`, released from an empty tag state.

The fixture generator already emits the placeholder (`internal/fixture/fixture.go:72`), `NextVersion("", ...)` already returns `v0.1.0` (`internal/bump/bump.go:64`), and `apply.go`'s modfile rewrite handles the placeholder transparently. This PR locks that contract with tests, so a regression in the first-user path can't slip in silently.

No production code changes.

## What changed

- **`internal/propagate/apply_test.go`** — new `TestApply_bootstrapFromPlaceholders`: zero-tag fixture, feat on storage, asserts `v0.1.0` tags on storage + api, the placeholder string is fully purged from `api/go.mod`, real `h1:` lines appear in `api/go.sum` for `storage v0.1.0`, and the atomic push lands train + both module tags on the local remote.
- **`test/integration/bootstrap_e2e_test.go`** (new, `integration` build tag) — `TestBootstrapFirstEverTag`: the shared test repo is pre-seeded with tagged modules, so a pure bootstrap isn't possible. Instead, the test adds a brand-new module on the per-run branch (module path never tagged on origin), releases with `--bump=minor`, and asserts `modules/<new>/v0.1.0` lands on origin atomically with the train tag. A `baselineTags` check proves the tag was genuinely new (not a re-push), distinguishing bootstrap from re-tag.

## Test plan

- [x] `go test ./internal/propagate/... -run TestApply_bootstrapFromPlaceholders -count=1`
- [x] `go test ./...` (full unit + local-E2E suite still green)
- [x] `go build -tags=integration ./test/integration/...` + `go vet -tags=integration ./...`
- [ ] `go test -tags=integration ./test/integration/... -run TestBootstrapFirstEverTag -count=1` (runs in CI; needs `MONOCO_TEST_REPO_TOKEN`)