### PR TITLE
feat(propagate): support v2+ major-version path rewriting

### DIFF
--- a/cmd/monoco/commands.go
+++ b/cmd/monoco/commands.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/matt0x6f/monoco/internal/bump"
+	"github.com/matt0x6f/monoco/internal/config"
 	"github.com/matt0x6f/monoco/internal/propagate"
 	"github.com/matt0x6f/monoco/internal/release"
 	"github.com/matt0x6f/monoco/internal/workspace"
@@ -21,17 +22,29 @@ type bumpFlag struct {
 func (b *bumpFlag) String() string     { return strings.Join(b.entries, ",") }
 func (b *bumpFlag) Set(v string) error { b.entries = append(b.entries, v); return nil }
 
+// repeatableFlag is a minimal flag.Value for repeatable string flags.
+type repeatableFlag struct{ entries []string }
+
+func (r *repeatableFlag) String() string     { return strings.Join(r.entries, ",") }
+func (r *repeatableFlag) Set(v string) error { r.entries = append(r.entries, v); return nil }
+
 func cmdRelease(root string, args []string) {
 	fs := flag.NewFlagSet("release", flag.ExitOnError)
 	var bumps bumpFlag
 	fs.Var(&bumps, "bump", "<module>=<major|minor|patch|skip> (repeatable) — override the default patch bump")
+	var allowMajor repeatableFlag
+	fs.Var(&allowMajor, "allow-major", "<module> (repeatable) — permit this module to cross a major version boundary")
 	remote := fs.String("remote", "origin", "remote to push to; set to \"\" to skip push")
 	slug := fs.String("slug", "", "train-tag slug (default: current branch)")
 	dryRun := fs.Bool("dry-run", false, "print plan and exit")
 	assumeYes := fs.Bool("y", false, "skip the Proceed? confirmation")
 	fs.Parse(args)
 
-	ws, err := workspace.Load(root)
+	cfg, err := config.Load(root)
+	if err != nil {
+		fatal(err)
+	}
+	ws, err := workspace.LoadWithConfig(root, cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -39,11 +52,16 @@ func cmdRelease(root string, args []string) {
 	if err != nil {
 		fatal(err)
 	}
+	allowMajorSet, err := resolveAllowMajor(ws, cfg.AllowMajorSet(), allowMajor.entries)
+	if err != nil {
+		fatal(err)
+	}
 
 	opts := release.Options{
-		Bumps:  bumpMap,
-		Slug:   *slug,
-		Remote: *remote,
+		Bumps:      bumpMap,
+		Slug:       *slug,
+		Remote:     *remote,
+		AllowMajor: allowMajorSet,
 	}
 
 	plan, err := release.Plan(ws, opts, os.Stdout)
@@ -80,6 +98,29 @@ func cmdRelease(root string, args []string) {
 	} else {
 		fmt.Println("Not pushed (remote unset or push skipped).")
 	}
+}
+
+// resolveAllowMajor unions CLI --allow-major entries with the manifest's
+// allow_major list, resolves each to its canonical module path, and
+// returns the set. An unknown entry is a hard error — typos should not
+// silently disable the boundary gate.
+func resolveAllowMajor(ws *workspace.Workspace, fromManifest map[string]struct{}, fromFlag []string) (map[string]struct{}, error) {
+	out := map[string]struct{}{}
+	for ref := range fromManifest {
+		mp, ok := propagate.ResolveModuleRef(ws, ref)
+		if !ok {
+			return nil, fmt.Errorf("allow_major %q: module not found in workspace", ref)
+		}
+		out[mp] = struct{}{}
+	}
+	for _, ref := range fromFlag {
+		mp, ok := propagate.ResolveModuleRef(ws, ref)
+		if !ok {
+			return nil, fmt.Errorf("--allow-major %q: module not found in workspace", ref)
+		}
+		out[mp] = struct{}{}
+	}
+	return out, nil
 }
 
 func parseBumpFlags(ws *workspace.Workspace, entries []string) (map[string]bump.Kind, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,13 @@ type Config struct {
 	// Recognized names: test, lint, build, generate. Unknown names are
 	// rejected. Any task name not present keeps its built-in default.
 	Tasks map[string]Task `yaml:"tasks"`
+
+	// AllowMajor lists module paths (as they appear in `go.mod`'s
+	// `module` line, without any `/vN` suffix) that may cross a major
+	// version boundary in a propagation. Absent entries are still
+	// rejected with a clear error — this gate is intentionally
+	// opt-in per module.
+	AllowMajor []string `yaml:"allow_major"`
 }
 
 // Task is one task-command override.
@@ -90,6 +97,18 @@ func (c *Config) ExcludedSet() map[string]struct{} {
 	return out
 }
 
+// AllowMajorSet returns AllowMajor as a set for O(1) membership checks.
+func (c *Config) AllowMajorSet() map[string]struct{} {
+	if c == nil {
+		return nil
+	}
+	out := make(map[string]struct{}, len(c.AllowMajor))
+	for _, m := range c.AllowMajor {
+		out[m] = struct{}{}
+	}
+	return out
+}
+
 // TaskCommand returns the configured command for task, or nil if the
 // manifest does not override it. Callers should use their built-in
 // default on nil.
@@ -117,6 +136,11 @@ func (c *Config) validate() error {
 		}
 		if strings.Contains(e, "..") {
 			return fmt.Errorf("exclude[%d] %q: must not contain `..`", i, e)
+		}
+	}
+	for i, m := range c.AllowMajor {
+		if strings.TrimSpace(m) == "" {
+			return fmt.Errorf("allow_major[%d]: empty entry", i)
 		}
 	}
 	for name, t := range c.Tasks {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -118,6 +118,38 @@ bogus: true
 	}
 }
 
+func TestLoad_parsesAllowMajor(t *testing.T) {
+	dir := writeManifest(t, `
+version: 1
+allow_major:
+  - example.com/acme/foo
+  - example.com/acme/bar
+`)
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	set := c.AllowMajorSet()
+	if _, ok := set["example.com/acme/foo"]; !ok {
+		t.Errorf("AllowMajorSet missing foo: %v", set)
+	}
+	if _, ok := set["example.com/acme/bar"]; !ok {
+		t.Errorf("AllowMajorSet missing bar: %v", set)
+	}
+}
+
+func TestLoad_rejectsEmptyAllowMajorEntry(t *testing.T) {
+	dir := writeManifest(t, `
+version: 1
+allow_major:
+  - ""
+`)
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "allow_major") {
+		t.Fatalf("want allow_major error, got %v", err)
+	}
+}
+
 func TestLoad_rejectsBadVersion(t *testing.T) {
 	dir := writeManifest(t, `version: 2`)
 	_, err := Load(dir)

--- a/internal/propagate/apply.go
+++ b/internal/propagate/apply.go
@@ -8,8 +8,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/matt0x6f/monoco/internal/propagate/importrewrite"
 	"github.com/matt0x6f/monoco/internal/workspace"
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/semver"
 )
 
 // ApplyOptions configures apply.
@@ -72,9 +74,18 @@ func Apply(ws *workspace.Workspace, plan *Plan, opts ApplyOptions) (*ApplyResult
 		return nil, fmt.Errorf("create release commit: %w", err)
 	}
 
-	// 3. Verify module-mode build.
-	paths := plan.ModulePaths()
-	if err := Verify(ws, paths); err != nil {
+	// 3. Verify module-mode build. Reload the workspace so the post-
+	// rewrite module paths (including any /vN majors) are visible.
+	verifyWS, err := workspace.Load(ws.Root)
+	if err != nil {
+		rollback()
+		return nil, fmt.Errorf("reload workspace for verify: %w", err)
+	}
+	paths := make([]string, 0, len(plan.Entries))
+	for _, e := range plan.Entries {
+		paths = append(paths, targetPath(e))
+	}
+	if err := Verify(verifyWS, paths); err != nil {
 		rollback()
 		return nil, fmt.Errorf("verify: %w", err)
 	}
@@ -129,11 +140,23 @@ func Apply(ws *workspace.Workspace, plan *Plan, opts ApplyOptions) (*ApplyResult
 
 // RewrittenMod describes the proposed rewrite of a single module.
 type RewrittenMod struct {
-	GoModPath string            // absolute path to go.mod
-	Old       []byte            // current bytes on disk
-	New       []byte            // proposed bytes after applying the plan
-	SumAdds   []string          // lines to append to this module's go.sum (may be empty)
-	GoSumPath string            // absolute path to go.sum (valid iff SumAdds non-empty)
+	GoModPath    string                      // absolute path to go.mod
+	Old          []byte                      // current bytes on disk
+	New          []byte                      // proposed bytes after applying the plan
+	SumAdds      []string                    // lines to append to this module's go.sum (may be empty)
+	GoSumPath    string                      // absolute path to go.sum (valid iff SumAdds non-empty)
+	GoFileEdits  []importrewrite.FileChange  // .go source rewrites for major-version path migrations
+	SkippedFiles []importrewrite.SkippedFile // .go files the rewriter skipped (build-tag gated)
+}
+
+// targetPath returns the module path as it will appear after applying
+// the plan. Major-version bumps append a /vN suffix; other entries are
+// unchanged.
+func targetPath(e Entry) string {
+	if !e.MajorBump {
+		return e.ModulePath
+	}
+	return e.ModulePath + "/" + semver.Major(e.NewVersion)
 }
 
 // ComputeRewrites returns the proposed go.mod rewrites + go.sum additions
@@ -145,27 +168,41 @@ type RewrittenMod struct {
 // in the plan. go.sum entries are computed for every freshly-tagged
 // module that any downstream in the plan depends on.
 func ComputeRewrites(ws *workspace.Workspace, plan *Plan) (map[string]RewrittenMod, error) {
-	newVersions := map[string]string{}
+	newVersions := map[string]string{}   // keyed by pre-plan module path
+	newPaths := map[string]string{}      // old path -> /vN-suffixed path (major bumpers only)
+	targetVersion := map[string]string{} // post-plan path -> new version
+	var rewrites []importrewrite.Rewrite
 	for _, e := range plan.Entries {
 		newVersions[e.ModulePath] = e.NewVersion
+		target := targetPath(e)
+		targetVersion[target] = e.NewVersion
+		if target != e.ModulePath {
+			newPaths[e.ModulePath] = target
+			rewrites = append(rewrites, importrewrite.Rewrite{
+				OldPath: e.ModulePath,
+				NewPath: target,
+			})
+		}
 	}
 
-	// Precompute canonical h1: hashes for each released module. The
-	// hash is over the module's current workspace contents — which, at
-	// release time, IS what will get tagged (we tag HEAD after rewrite).
+	// Precompute canonical h1: hashes for each released module, keyed
+	// by the module's post-plan path (so entries generated from a
+	// /vN-rewritten go.mod line up).
 	hashes := map[string]ModuleHashes{}
 	for _, e := range plan.Entries {
 		dir := ws.Modules[e.ModulePath].Dir
-		h, err := ComputeModuleHashes(dir, e.ModulePath, e.NewVersion)
+		target := targetPath(e)
+		h, err := ComputeModuleHashes(dir, target, e.NewVersion)
 		if err != nil {
-			return nil, fmt.Errorf("hash %s@%s: %w", e.ModulePath, e.NewVersion, err)
+			return nil, fmt.Errorf("hash %s@%s: %w", target, e.NewVersion, err)
 		}
-		hashes[e.ModulePath] = h
+		hashes[target] = h
 	}
 
 	out := map[string]RewrittenMod{}
 	for _, e := range plan.Entries {
-		goModPath := filepath.Join(ws.Modules[e.ModulePath].Dir, "go.mod")
+		modDir := ws.Modules[e.ModulePath].Dir
+		goModPath := filepath.Join(modDir, "go.mod")
 		b, err := os.ReadFile(goModPath)
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", goModPath, err)
@@ -176,23 +213,47 @@ func ComputeRewrites(ws *workspace.Workspace, plan *Plan) (map[string]RewrittenM
 		}
 
 		modChanged := false
-		referencedDeps := map[string]struct{}{}
+		referencedDeps := map[string]struct{}{} // post-plan paths
 
-		// Bump require versions for in-plan deps.
-		for _, req := range mf.Require {
-			if newV, inPlan := newVersions[req.Mod.Path]; inPlan {
-				if err := mf.AddRequire(req.Mod.Path, newV); err != nil {
-					return nil, fmt.Errorf("update require %s: %w", req.Mod.Path, err)
-				}
-				referencedDeps[req.Mod.Path] = struct{}{}
-				modChanged = true
+		// Rewrite this module's own `module` directive when it's the
+		// major-bumper (adds the /vN suffix).
+		if e.MajorBump {
+			if err := mf.AddModuleStmt(newPaths[e.ModulePath]); err != nil {
+				return nil, fmt.Errorf("set module %s: %w", newPaths[e.ModulePath], err)
 			}
+			modChanged = true
+		}
+
+		// Plan require-line updates without mutating while iterating.
+		type reqChange struct{ oldPath, newPath, newVersion string }
+		var reqChanges []reqChange
+		for _, req := range mf.Require {
+			newV, inPlan := newVersions[req.Mod.Path]
+			if !inPlan {
+				continue
+			}
+			np := req.Mod.Path
+			if nm, ok := newPaths[req.Mod.Path]; ok {
+				np = nm
+			}
+			reqChanges = append(reqChanges, reqChange{req.Mod.Path, np, newV})
+		}
+		for _, c := range reqChanges {
+			if c.oldPath != c.newPath {
+				if err := mf.DropRequire(c.oldPath); err != nil {
+					return nil, fmt.Errorf("drop require %s: %w", c.oldPath, err)
+				}
+			}
+			if err := mf.AddRequire(c.newPath, c.newVersion); err != nil {
+				return nil, fmt.Errorf("add require %s: %w", c.newPath, err)
+			}
+			referencedDeps[c.newPath] = struct{}{}
+			modChanged = true
 		}
 
 		// Drop workspace-local replaces for in-plan deps. A replace is
 		// "workspace-local" iff its New.Version is empty (path replacement)
 		// and resolves to a workspace module's dir.
-		modDir := ws.Modules[e.ModulePath].Dir
 		for _, r := range mf.Replace {
 			if r.New.Version != "" {
 				continue
@@ -226,7 +287,7 @@ func ComputeRewrites(ws *workspace.Workspace, plan *Plan) (map[string]RewrittenM
 		var sumAdds []string
 		for dep := range referencedDeps {
 			h := hashes[dep]
-			depV := newVersions[dep]
+			depV := targetVersion[dep]
 			sumAdds = append(sumAdds,
 				fmt.Sprintf("%s %s %s", dep, depV, h.H1),
 				fmt.Sprintf("%s %s/go.mod %s", dep, depV, h.H1Mod),
@@ -234,7 +295,22 @@ func ComputeRewrites(ws *workspace.Workspace, plan *Plan) (map[string]RewrittenM
 		}
 		sort.Strings(sumAdds)
 
-		if !modChanged && len(sumAdds) == 0 {
+		// Rewrite any .go files whose imports reference a major-bumped
+		// module (affects this module iff any such bumper exists in
+		// the plan). Applied to every entry — including the bumper
+		// itself, which may import its own subpackages by full path.
+		var goEdits []importrewrite.FileChange
+		var skipped []importrewrite.SkippedFile
+		if len(rewrites) > 0 {
+			rep, rerr := importrewrite.RewriteConsumer(modDir, rewrites)
+			if rerr != nil {
+				return nil, fmt.Errorf("rewrite imports in %s: %w", modDir, rerr)
+			}
+			goEdits = rep.Changes
+			skipped = rep.SkippedFiles
+		}
+
+		if !modChanged && len(sumAdds) == 0 && len(goEdits) == 0 {
 			continue
 		}
 
@@ -244,7 +320,14 @@ func ComputeRewrites(ws *workspace.Workspace, plan *Plan) (map[string]RewrittenM
 			return nil, fmt.Errorf("format %s: %w", goModPath, err)
 		}
 
-		r := RewrittenMod{GoModPath: goModPath, Old: b, New: formatted, SumAdds: sumAdds}
+		r := RewrittenMod{
+			GoModPath:    goModPath,
+			Old:          b,
+			New:          formatted,
+			SumAdds:      sumAdds,
+			GoFileEdits:  goEdits,
+			SkippedFiles: skipped,
+		}
 		if len(sumAdds) > 0 {
 			r.GoSumPath = filepath.Join(ws.Modules[e.ModulePath].Dir, "go.sum")
 		}
@@ -264,6 +347,11 @@ func rewriteGoMods(ws *workspace.Workspace, plan *Plan) error {
 		if !bytes.Equal(r.Old, r.New) {
 			if err := os.WriteFile(r.GoModPath, r.New, 0o644); err != nil {
 				return fmt.Errorf("write %s: %w", r.GoModPath, err)
+			}
+		}
+		for _, fc := range r.GoFileEdits {
+			if err := os.WriteFile(fc.Path, fc.New, 0o644); err != nil {
+				return fmt.Errorf("write %s: %w", fc.Path, err)
 			}
 		}
 		if len(r.SumAdds) == 0 {

--- a/internal/propagate/apply_major_test.go
+++ b/internal/propagate/apply_major_test.go
@@ -1,0 +1,108 @@
+package propagate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/matt0x6f/monoco/internal/bump"
+	"github.com/matt0x6f/monoco/internal/fixture"
+	"github.com/matt0x6f/monoco/internal/workspace"
+)
+
+// TestApply_majorBumpRewritesPathsAndImports exercises the full
+// v1→v2 rewrite path: module directive, downstream requires, .go
+// import specs, tags, and the module-mode Verify step.
+func TestApply_majorBumpRewritesPathsAndImports(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "api", DependsOn: []string{"storage"}},
+		},
+	})
+	run(t, fx.Root, "git", "tag", "modules/storage/v1.0.0")
+	run(t, fx.Root, "git", "tag", "modules/api/v1.0.0")
+	run(t, fx.Root, "git", "push", "origin", "main", "--tags")
+
+	// Simulate an in-progress storage change so it's eligible to release.
+	writeFile(t, filepath.Join(fx.Root, "modules/storage/storage.go"),
+		"package storage\n\nfunc StorageHello() string { return \"v2-new\" }\n")
+	run(t, fx.Root, "git", "add", "-A")
+	run(t, fx.Root, "git", "commit", "-m", "storage: breaking change")
+
+	ws, _ := workspace.Load(fx.Root)
+	plan, err := NewPlanForModules(ws, []string{"example.com/mono/storage"}, Options{
+		Slug:       "major-test",
+		Bumps:      map[string]bump.Kind{"example.com/mono/storage": bump.Major},
+		AllowMajor: map[string]struct{}{"example.com/mono/storage": {}},
+	})
+	if err != nil {
+		t.Fatalf("NewPlanForModules: %v", err)
+	}
+
+	storageEntry := findEntry(plan, "example.com/mono/storage")
+	if storageEntry == nil || !storageEntry.MajorBump || storageEntry.NewVersion != "v2.0.0" {
+		t.Fatalf("storage entry wrong: %+v", storageEntry)
+	}
+
+	if _, err := Apply(ws, plan, ApplyOptions{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// storage/go.mod's module directive should now carry /v2.
+	storageMod, err := os.ReadFile(filepath.Join(fx.Root, "modules/storage/go.mod"))
+	if err != nil {
+		t.Fatalf("read storage/go.mod: %v", err)
+	}
+	if !strings.Contains(string(storageMod), "module example.com/mono/storage/v2") {
+		t.Errorf("storage/go.mod module directive not rewritten:\n%s", storageMod)
+	}
+
+	// api/go.mod: require rewritten to /v2 at v2.0.0.
+	apiMod, err := os.ReadFile(filepath.Join(fx.Root, "modules/api/go.mod"))
+	if err != nil {
+		t.Fatalf("read api/go.mod: %v", err)
+	}
+	if !strings.Contains(string(apiMod), "example.com/mono/storage/v2 v2.0.0") {
+		t.Errorf("api/go.mod require not rewritten:\n%s", apiMod)
+	}
+	if strings.Contains(string(apiMod), "example.com/mono/storage v") && !strings.Contains(string(apiMod), "example.com/mono/storage/v2") {
+		t.Errorf("api/go.mod still has old require path:\n%s", apiMod)
+	}
+
+	// api/api.go: import spec rewritten to /v2.
+	apiSrc, err := os.ReadFile(filepath.Join(fx.Root, "modules/api/api.go"))
+	if err != nil {
+		t.Fatalf("read api/api.go: %v", err)
+	}
+	if !strings.Contains(string(apiSrc), `"example.com/mono/storage/v2"`) {
+		t.Errorf("api/api.go import not rewritten:\n%s", apiSrc)
+	}
+
+	// Tag for the major version exists.
+	if !tagExists(t, fx.Root, "modules/storage/v2.0.0") {
+		t.Error("missing tag modules/storage/v2.0.0")
+	}
+	if !tagExists(t, fx.Root, "modules/api/v1.0.1") {
+		t.Error("missing cascade tag modules/api/v1.0.1")
+	}
+}
+
+// TestApply_majorBumpWithoutAllowRejects keeps the existing fail-closed
+// behavior for the un-opted-in case.
+func TestApply_majorBumpWithoutAllowRejects(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	run(t, fx.Root, "git", "tag", "modules/storage/v1.0.0")
+	ws, _ := workspace.Load(fx.Root)
+
+	_, err := NewPlanForModules(ws, []string{"example.com/mono/storage"}, Options{
+		Slug:  "test",
+		Bumps: map[string]bump.Kind{"example.com/mono/storage": bump.Major},
+	})
+	if err == nil {
+		t.Fatal("expected reject without AllowMajor")
+	}
+}

--- a/internal/propagate/importrewrite/importrewrite.go
+++ b/internal/propagate/importrewrite/importrewrite.go
@@ -1,0 +1,191 @@
+// Package importrewrite rewrites Go source imports and go.mod module
+// directives to add a major-version (/vN) suffix. It is used only when a
+// plan includes a v1→v2+ boundary crossing (gated by --allow-major).
+//
+// Rewriting is AST-based (go/parser + go/ast + go/format). Files whose
+// build constraints exclude them from the default platform are skipped
+// and reported — the module-mode Verify step is the backstop for any
+// import the rewriter missed.
+package importrewrite
+
+import (
+	"bytes"
+	"fmt"
+	"go/build"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+)
+
+// Rewrite describes one module-path substitution.
+type Rewrite struct {
+	OldPath string // e.g. "example.com/acme/foo"
+	NewPath string // e.g. "example.com/acme/foo/v2"
+}
+
+// FileChange is one proposed edit to a .go source file.
+type FileChange struct {
+	Path string // absolute path
+	Old  []byte
+	New  []byte
+}
+
+// SkippedFile records a .go source file the rewriter intentionally did
+// not touch, along with the reason. Verify will catch any missed imports
+// at build time.
+type SkippedFile struct {
+	Path   string
+	Reason string
+}
+
+// Report is the outcome of rewriting a consumer module.
+type Report struct {
+	Changes      []FileChange
+	SkippedFiles []SkippedFile
+}
+
+// RewriteModuleDirective returns go.mod bytes with the `module` line set
+// to newPath. It is a no-op (returns the input unchanged) if the module
+// directive already equals newPath.
+func RewriteModuleDirective(goModBytes []byte, newPath string) ([]byte, error) {
+	mf, err := modfile.Parse("go.mod", goModBytes, nil)
+	if err != nil {
+		return nil, fmt.Errorf("parse go.mod: %w", err)
+	}
+	if mf.Module != nil && mf.Module.Mod.Path == newPath {
+		return goModBytes, nil
+	}
+	if err := mf.AddModuleStmt(newPath); err != nil {
+		return nil, fmt.Errorf("set module %s: %w", newPath, err)
+	}
+	mf.Cleanup()
+	out, err := mf.Format()
+	if err != nil {
+		return nil, fmt.Errorf("format go.mod: %w", err)
+	}
+	return out, nil
+}
+
+// RewriteConsumer walks moduleDir, rewriting any .go file's import specs
+// whose path matches a Rewrite.OldPath. Returns the set of changes plus
+// any files skipped due to build-constraint mismatches.
+//
+// Skipped files are reported but not an error: Verify will catch any
+// import the rewriter didn't update when building for the default
+// platform. Exotic-platform files (e.g. foo_plan9.go) get the same
+// treatment as before the rewrite — unchanged, and only reachable on
+// that platform.
+func RewriteConsumer(moduleDir string, rewrites []Rewrite) (*Report, error) {
+	if len(rewrites) == 0 {
+		return &Report{}, nil
+	}
+	index := map[string]string{}
+	for _, r := range rewrites {
+		if r.OldPath == "" || r.NewPath == "" {
+			return nil, fmt.Errorf("invalid rewrite: old=%q new=%q", r.OldPath, r.NewPath)
+		}
+		index[r.OldPath] = r.NewPath
+	}
+
+	rep := &Report{}
+	bctx := build.Default
+	err := filepath.WalkDir(moduleDir, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			name := d.Name()
+			// Skip common non-source directories and nested modules.
+			if path != moduleDir && (name == "testdata" || name == "vendor" || strings.HasPrefix(name, ".")) {
+				return fs.SkipDir
+			}
+			if path != moduleDir {
+				// Nested modules (their own go.mod) are out of scope:
+				// the plan handles them as separate entries.
+				if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+					return fs.SkipDir
+				}
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		dir := filepath.Dir(path)
+		name := filepath.Base(path)
+		match, err := bctx.MatchFile(dir, name)
+		if err != nil {
+			// Malformed build tag or similar — skip, record reason.
+			rep.SkippedFiles = append(rep.SkippedFiles, SkippedFile{
+				Path:   path,
+				Reason: fmt.Sprintf("build.MatchFile: %v", err),
+			})
+			return nil
+		}
+		if !match {
+			rep.SkippedFiles = append(rep.SkippedFiles, SkippedFile{
+				Path:   path,
+				Reason: "build constraints exclude this file on the default platform",
+			})
+			return nil
+		}
+		change, err := rewriteFile(path, index)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		if change != nil {
+			rep.Changes = append(rep.Changes, *change)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return rep, nil
+}
+
+// rewriteFile parses path, rewrites matching import specs, and returns a
+// FileChange if anything changed. Returns nil, nil when the file had no
+// matching imports.
+func rewriteFile(path string, index map[string]string) (*FileChange, error) {
+	fset := token.NewFileSet()
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	file, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	modified := false
+	for _, imp := range file.Imports {
+		if imp.Path == nil {
+			continue
+		}
+		p, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			continue
+		}
+		newPath, ok := index[p]
+		if !ok {
+			continue
+		}
+		imp.Path.Value = strconv.Quote(newPath)
+		modified = true
+	}
+	if !modified {
+		return nil, nil
+	}
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fset, file); err != nil {
+		return nil, fmt.Errorf("format: %w", err)
+	}
+	return &FileChange{Path: path, Old: src, New: buf.Bytes()}, nil
+}

--- a/internal/propagate/importrewrite/importrewrite_test.go
+++ b/internal/propagate/importrewrite/importrewrite_test.go
@@ -1,0 +1,186 @@
+package importrewrite
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRewriteModuleDirective_setsVN(t *testing.T) {
+	in := []byte("module example.com/acme/foo\n\ngo 1.22\n")
+	out, err := RewriteModuleDirective(in, "example.com/acme/foo/v2")
+	if err != nil {
+		t.Fatalf("RewriteModuleDirective: %v", err)
+	}
+	if !strings.Contains(string(out), "module example.com/acme/foo/v2") {
+		t.Fatalf("expected rewritten module line, got:\n%s", out)
+	}
+}
+
+func TestRewriteModuleDirective_idempotent(t *testing.T) {
+	in := []byte("module example.com/acme/foo/v2\n\ngo 1.22\n")
+	out, err := RewriteModuleDirective(in, "example.com/acme/foo/v2")
+	if err != nil {
+		t.Fatalf("RewriteModuleDirective: %v", err)
+	}
+	if string(out) != string(in) {
+		t.Fatalf("expected byte-identical output on idempotent call\ngot:  %q\nwant: %q", out, in)
+	}
+}
+
+func TestRewriteConsumer_bareImport(t *testing.T) {
+	dir := t.TempDir()
+	src := `package foo
+
+import "example.com/acme/bar"
+
+var _ = bar.Hello
+`
+	writeGo(t, dir, "foo.go", src)
+
+	rep, err := RewriteConsumer(dir, []Rewrite{{OldPath: "example.com/acme/bar", NewPath: "example.com/acme/bar/v2"}})
+	if err != nil {
+		t.Fatalf("RewriteConsumer: %v", err)
+	}
+	if len(rep.Changes) != 1 {
+		t.Fatalf("expected 1 change, got %d (%v)", len(rep.Changes), rep.Changes)
+	}
+	got := string(rep.Changes[0].New)
+	if !strings.Contains(got, `"example.com/acme/bar/v2"`) {
+		t.Fatalf("expected rewritten import, got:\n%s", got)
+	}
+}
+
+func TestRewriteConsumer_aliasedImportPreserved(t *testing.T) {
+	dir := t.TempDir()
+	src := `package foo
+
+import bar "example.com/acme/bar"
+
+var _ = bar.Hello
+`
+	writeGo(t, dir, "foo.go", src)
+
+	rep, err := RewriteConsumer(dir, []Rewrite{{OldPath: "example.com/acme/bar", NewPath: "example.com/acme/bar/v2"}})
+	if err != nil {
+		t.Fatalf("RewriteConsumer: %v", err)
+	}
+	if len(rep.Changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(rep.Changes))
+	}
+	got := string(rep.Changes[0].New)
+	if !strings.Contains(got, `bar "example.com/acme/bar/v2"`) {
+		t.Fatalf("expected alias preserved, got:\n%s", got)
+	}
+}
+
+func TestRewriteConsumer_dotAndBlankImports(t *testing.T) {
+	dir := t.TempDir()
+	src := `package foo
+
+import (
+	. "example.com/acme/bar"
+	_ "example.com/acme/bar/side"
+)
+`
+	writeGo(t, dir, "foo.go", src)
+
+	rep, err := RewriteConsumer(dir, []Rewrite{
+		{OldPath: "example.com/acme/bar", NewPath: "example.com/acme/bar/v2"},
+		{OldPath: "example.com/acme/bar/side", NewPath: "example.com/acme/bar/v2/side"},
+	})
+	if err != nil {
+		t.Fatalf("RewriteConsumer: %v", err)
+	}
+	if len(rep.Changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(rep.Changes))
+	}
+	got := string(rep.Changes[0].New)
+	if !strings.Contains(got, `. "example.com/acme/bar/v2"`) {
+		t.Fatalf("expected dot import rewritten, got:\n%s", got)
+	}
+	if !strings.Contains(got, `_ "example.com/acme/bar/v2/side"`) {
+		t.Fatalf("expected blank import rewritten, got:\n%s", got)
+	}
+}
+
+func TestRewriteConsumer_skipsNonMatchingImports(t *testing.T) {
+	dir := t.TempDir()
+	src := `package foo
+
+import (
+	"example.com/acme/other"
+)
+
+var _ = other.X
+`
+	writeGo(t, dir, "foo.go", src)
+
+	rep, err := RewriteConsumer(dir, []Rewrite{{OldPath: "example.com/acme/bar", NewPath: "example.com/acme/bar/v2"}})
+	if err != nil {
+		t.Fatalf("RewriteConsumer: %v", err)
+	}
+	if len(rep.Changes) != 0 {
+		t.Fatalf("expected no changes, got %d", len(rep.Changes))
+	}
+}
+
+func TestRewriteConsumer_skipsBuildTagMismatch(t *testing.T) {
+	dir := t.TempDir()
+	src := `//go:build never_satisfied_tag_xyz
+
+package foo
+
+import "example.com/acme/bar"
+
+var _ = bar.Hello
+`
+	writeGo(t, dir, "foo_tagged.go", src)
+
+	rep, err := RewriteConsumer(dir, []Rewrite{{OldPath: "example.com/acme/bar", NewPath: "example.com/acme/bar/v2"}})
+	if err != nil {
+		t.Fatalf("RewriteConsumer: %v", err)
+	}
+	if len(rep.Changes) != 0 {
+		t.Fatalf("expected file to be skipped, got %d changes", len(rep.Changes))
+	}
+	if len(rep.SkippedFiles) != 1 {
+		t.Fatalf("expected 1 skipped file, got %d", len(rep.SkippedFiles))
+	}
+}
+
+func TestRewriteConsumer_skipsNestedModule(t *testing.T) {
+	dir := t.TempDir()
+	writeGo(t, dir, "top.go", "package foo\n\nimport \"example.com/acme/bar\"\n\nvar _ = bar.Hello\n")
+
+	nested := filepath.Join(dir, "nested")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(nested, "go.mod"), "module example.com/other\n\ngo 1.22\n")
+	writeGo(t, nested, "other.go", "package other\n\nimport \"example.com/acme/bar\"\n\nvar _ = bar.Hello\n")
+
+	rep, err := RewriteConsumer(dir, []Rewrite{{OldPath: "example.com/acme/bar", NewPath: "example.com/acme/bar/v2"}})
+	if err != nil {
+		t.Fatalf("RewriteConsumer: %v", err)
+	}
+	if len(rep.Changes) != 1 {
+		t.Fatalf("expected 1 change (only top.go), got %d", len(rep.Changes))
+	}
+	if !strings.HasSuffix(rep.Changes[0].Path, "top.go") {
+		t.Fatalf("wrong file rewritten: %s", rep.Changes[0].Path)
+	}
+}
+
+func writeGo(t *testing.T, dir, name, content string) {
+	t.Helper()
+	writeFile(t, filepath.Join(dir, name), content)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/propagate/plan.go
+++ b/internal/propagate/plan.go
@@ -29,6 +29,11 @@ type Options struct {
 	// NOT need an entry. A Skip entry drops that module from the plan.
 	// A direct-affected module without an entry is a fail-closed error.
 	Bumps map[string]bump.Kind
+	// AllowMajor is the set of module paths permitted to cross a major
+	// version boundary in this plan. Keyed by the module's current
+	// path (the form in go.mod's `module` line, without any `/vN`
+	// suffix). At most one module per plan may cross; see buildPlan.
+	AllowMajor map[string]struct{}
 }
 
 // Entry is one module's slice of a plan.
@@ -40,6 +45,7 @@ type Entry struct {
 	Kind         bump.Kind // bump kind applied
 	TagName      string    // <RelDir>/<NewVersion>
 	DirectChange bool      // true if affected by a replace; false if cascaded
+	MajorBump    bool      // true if this entry crosses a major version boundary
 }
 
 // Plan is a deterministic propagation plan.
@@ -163,8 +169,12 @@ func buildPlan(ws *workspace.Workspace, modules []string, directSet map[string]s
 		return nil, fmt.Errorf("no bump specified for direct-affected module(s): %s", strings.Join(missing, ", "))
 	}
 
-	// Compute new versions. Reject v1→v2 crossings for monoco v1.
+	// Compute new versions. Major-boundary crossings are gated by
+	// opts.AllowMajor, and at most one per plan is permitted (keeps
+	// import-path rewrite scope bounded).
 	versions := map[string]string{}
+	majorBumps := map[string]bool{}
+	var majorBumpers []string
 	for modPath, kind := range bumps {
 		old := oldVersions[modPath]
 		newV, err := bump.NextVersion(old, kind)
@@ -172,9 +182,17 @@ func buildPlan(ws *workspace.Workspace, modules []string, directSet map[string]s
 			return nil, fmt.Errorf("next version for %s: %w", modPath, err)
 		}
 		if old != "" && semver.Major(newV) != semver.Major(old) {
-			return nil, fmt.Errorf("module %s would cross major version boundary (%s → %s); v2+ path rewrites are not supported in monoco v1", modPath, old, newV)
+			if _, ok := opts.AllowMajor[modPath]; !ok {
+				return nil, fmt.Errorf("module %s would cross major version boundary (%s → %s); pass --allow-major %s or set allow_major in monoco.yaml", modPath, old, newV, modPath)
+			}
+			majorBumps[modPath] = true
+			majorBumpers = append(majorBumpers, modPath)
 		}
 		versions[modPath] = newV
+	}
+	if len(majorBumpers) > 1 {
+		sort.Strings(majorBumpers)
+		return nil, fmt.Errorf("at most one module per propagation may cross a major boundary; got: %s", strings.Join(majorBumpers, ", "))
 	}
 
 	// Filter skipped modules out of the module set, then topo-order.
@@ -200,6 +218,7 @@ func buildPlan(ws *workspace.Workspace, modules []string, directSet map[string]s
 			Kind:         bumps[modPath],
 			TagName:      rel + "/" + versions[modPath],
 			DirectChange: isDirect,
+			MajorBump:    majorBumps[modPath],
 		})
 	}
 

--- a/internal/propagate/plan_test.go
+++ b/internal/propagate/plan_test.go
@@ -87,7 +87,7 @@ func TestNewPlanForModules_skipDropsModule(t *testing.T) {
 	}
 }
 
-func TestNewPlanForModules_rejectsMajorBumpV1ToV2(t *testing.T) {
+func TestNewPlanForModules_rejectsMajorBumpWithoutAllow(t *testing.T) {
 	fx := fixture.New(t, fixture.Spec{
 		Modules: []fixture.ModuleSpec{{Name: "storage"}},
 	})
@@ -99,7 +99,67 @@ func TestNewPlanForModules_rejectsMajorBumpV1ToV2(t *testing.T) {
 		Bumps: map[string]bump.Kind{"example.com/mono/storage": bump.Major},
 	})
 	if err == nil {
-		t.Fatal("expected v1→v2 rejection")
+		t.Fatal("expected v1→v2 rejection without --allow-major")
+	}
+	if !strings.Contains(err.Error(), "--allow-major") {
+		t.Errorf("error should mention --allow-major, got: %v", err)
+	}
+}
+
+func TestNewPlanForModules_allowsMajorBumpWhenOptedIn(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	run(t, fx.Root, "git", "tag", "modules/storage/v1.0.0")
+	ws, _ := workspace.Load(fx.Root)
+
+	plan, err := NewPlanForModules(ws, []string{"example.com/mono/storage"}, Options{
+		Slug:       "test",
+		Bumps:      map[string]bump.Kind{"example.com/mono/storage": bump.Major},
+		AllowMajor: map[string]struct{}{"example.com/mono/storage": {}},
+	})
+	if err != nil {
+		t.Fatalf("NewPlanForModules: %v", err)
+	}
+	e := findEntry(plan, "example.com/mono/storage")
+	if e == nil || !e.MajorBump {
+		t.Fatalf("expected MajorBump=true, got: %+v", e)
+	}
+	if e.NewVersion != "v2.0.0" {
+		t.Errorf("expected v2.0.0, got %s", e.NewVersion)
+	}
+}
+
+func TestNewPlanForModules_rejectsMultipleMajorBumps(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "cache"},
+		},
+	})
+	run(t, fx.Root, "git", "tag", "modules/storage/v1.0.0")
+	run(t, fx.Root, "git", "tag", "modules/cache/v1.0.0")
+	ws, _ := workspace.Load(fx.Root)
+
+	_, err := NewPlanForModules(ws, []string{"example.com/mono/storage", "example.com/mono/cache"}, Options{
+		Slug: "test",
+		Bumps: map[string]bump.Kind{
+			"example.com/mono/storage": bump.Major,
+			"example.com/mono/cache":   bump.Major,
+		},
+		AllowMajor: map[string]struct{}{
+			"example.com/mono/storage": {},
+			"example.com/mono/cache":   {},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when two modules cross major in one plan")
+	}
+	if !strings.Contains(err.Error(), "at most one") {
+		t.Errorf("error should explain the limit, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "storage") || !strings.Contains(err.Error(), "cache") {
+		t.Errorf("error should name both modules, got: %v", err)
 	}
 }
 

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -27,6 +27,10 @@ type Options struct {
 	Slug string
 	// Remote is the push target. "" skips push.
 	Remote string
+	// AllowMajor is the set of module paths permitted to cross a major
+	// version boundary in this release. Typically unioned from the
+	// --allow-major CLI flag and monoco.yaml's allow_major entries.
+	AllowMajor map[string]struct{}
 }
 
 // Plan gathers affected modules, applies bump kinds (default patch,
@@ -54,8 +58,9 @@ func Plan(ws *workspace.Workspace, opts Options, stdout io.Writer) (*propagate.P
 	}
 
 	plan, err := propagate.NewPlanForModules(ws, directs, propagate.Options{
-		Slug:  opts.Slug,
-		Bumps: bumps,
+		Slug:       opts.Slug,
+		Bumps:      bumps,
+		AllowMajor: opts.AllowMajor,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #2.

## Summary

- Opt-in major-version boundary crossing, gated by `--allow-major <module>` (CLI, repeatable) or `allow_major` in `monoco.yaml`. Never silent.
- Rewrites the bumping module's `module` directive, every downstream `require` line, and every downstream `.go` file's import specs to add the `/vN` suffix.
- AST-based import rewriting (`go/parser` + `go/ast` + `go/format`); no regex. Files excluded by build constraints on the default platform are recorded and skipped — `Verify` catches anything missed.
- At most one module per propagation may cross a major boundary.

## Key changes

- `internal/propagate/importrewrite/` — new package. `RewriteModuleDirective` for go.mod; `RewriteConsumer` for `.go` files. Skips nested modules, `vendor/`, `testdata/`, and build-tag-excluded files.
- `internal/propagate/plan.go` — `Options.AllowMajor`, `Entry.MajorBump`. Replaces the hard-refuse with an opt-in gate; enforces at-most-one-per-plan.
- `internal/propagate/apply.go` — `RewrittenMod.GoFileEdits` threads `.go` edits through the existing atomic Apply path. Post-plan paths used for hashes, go.sum additions, and requires. Workspace is reloaded before `Verify` so post-rewrite module identities resolve.
- `internal/config/config.go` — `AllowMajor []string` manifest field + `AllowMajorSet()` helper.
- `internal/release/release.go` and `cmd/monoco/commands.go` — `Options.AllowMajor` plumbed end-to-end; `--allow-major` CLI flag unions with manifest entries.

## Design notes

- Go's "major-branch" convention keeps the module in the same directory; only the `module` directive changes to `.../vN`. Tag name (`<reldir>/vN.M.P`) is already correct without change.
- Rollback is unchanged: `.go` edits are tracked by git, so `git reset --hard oldHead` undoes them along with go.mod/go.sum rewrites.
- No new module dependencies — only stdlib (`go/parser`, `go/ast`, `go/format`, `go/build`) and existing `golang.org/x/mod`.

## Test plan

- [x] `go test ./...` — all 14 packages pass, including new unit tests and the new `TestApply_majorBumpRewritesPathsAndImports` E2E fixture test that exercises the full rewrite + `Verify` path.
- [x] `go vet ./...` clean.
- [x] New tests cover: major-bump rejection without opt-in, successful bump with opt-in, two-major-bumps-in-one-plan rejection, AST rewriter across bare/aliased/dot/blank imports, build-tag skip, nested-module skip, module-directive idempotence, and manifest parsing / validation of `allow_major`.