### PR TITLE
fix(release): unblock integration tests — fresh branches, lone modules, empty commits

### DIFF
--- a/internal/propagate/apply.go
+++ b/internal/propagate/apply.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -85,14 +86,24 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 		return nil, fmt.Errorf("rewrite go.mods: %w", err)
 	}
 
-	// 2. Create the release commit.
+	// 2. Create the release commit (only if rewrites actually changed
+	// anything on disk). Bootstrap releases of modules with no in-tree
+	// consumers produce zero go.mod rewrites, so there's nothing to
+	// commit — we tag the existing HEAD instead.
 	if _, err := shellGit(ws.Root, "add", "-A"); err != nil {
 		rollback()
 		return nil, err
 	}
-	if _, err := shellGit(ws.Root, "commit", "-m", plan.CommitMsg); err != nil {
+	hasStaged, err := hasStagedChanges(ws.Root)
+	if err != nil {
 		rollback()
-		return nil, fmt.Errorf("create release commit: %w", err)
+		return nil, err
+	}
+	if hasStaged {
+		if _, err := shellGit(ws.Root, "commit", "-m", plan.CommitMsg); err != nil {
+			rollback()
+			return nil, fmt.Errorf("create release commit: %w", err)
+		}
 	}
 
 	// 3. Verify module-mode build. Reload the workspace so the post-
@@ -483,6 +494,21 @@ func isProtectedBranchLeaseReject(err error) bool {
 		return true
 	}
 	return false
+}
+
+// hasStagedChanges reports whether `git add -A` left anything staged.
+// `git diff --cached --quiet` exits 0 when the index matches HEAD, 1
+// when it differs.
+func hasStagedChanges(root string) (bool, error) {
+	cmd := exec.Command("git", "-C", root, "diff", "--cached", "--quiet")
+	err := cmd.Run()
+	if err == nil {
+		return false, nil
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+		return true, nil
+	}
+	return false, fmt.Errorf("git diff --cached: %w", err)
 }
 
 func tagAlreadyAt(root, tag, sha string) bool {

--- a/internal/propagate/apply_test.go
+++ b/internal/propagate/apply_test.go
@@ -233,6 +233,59 @@ func TestApply_bootstrapFromPlaceholders(t *testing.T) {
 	}
 }
 
+// TestApply_loneModuleSkipsReleaseCommit covers the bootstrap case
+// where a module has no in-tree consumers: there are no go.mod
+// rewrites to stage, so no release commit is created. The module tag
+// and train tag must land on the existing HEAD.
+func TestApply_loneModuleSkipsReleaseCommit(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	run(t, fx.Root, "git", "push", "origin", "main")
+
+	headBefore := headSHA(t, fx.Root)
+
+	ws, _ := workspace.Load(fx.Root)
+	plan, err := NewPlanForModules(ws, []string{"example.com/mono/storage"}, Options{
+		Slug:  "lone",
+		Bumps: map[string]bump.Kind{"example.com/mono/storage": bump.Minor},
+	})
+	if err != nil {
+		t.Fatalf("NewPlanForModules: %v", err)
+	}
+
+	res, err := Apply(ws, plan, ApplyOptions{Remote: "origin"})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	headAfter := headSHA(t, fx.Root)
+	if headAfter != headBefore {
+		t.Errorf("HEAD advanced (%s -> %s); expected no release commit for lone module",
+			headBefore, headAfter)
+	}
+	if res.ReleaseCommit != headBefore {
+		t.Errorf("ReleaseCommit = %s; want pre-apply HEAD %s", res.ReleaseCommit, headBefore)
+	}
+
+	for _, tg := range []string{"modules/storage/v0.1.0", plan.TrainTag} {
+		if !tagExists(t, fx.Root, tg) {
+			t.Errorf("missing local tag %s", tg)
+			continue
+		}
+		if got := tagSHA(t, fx.Root, tg); got != headBefore {
+			t.Errorf("tag %s points at %s, not HEAD %s", tg, got, headBefore)
+		}
+	}
+
+	remoteTags := remoteTagList(t, fx.RemoteDir)
+	for _, tg := range []string{"modules/storage/v0.1.0", plan.TrainTag} {
+		if !sliceContains(remoteTags, tg) {
+			t.Errorf("remote missing %s; has %v", tg, remoteTags)
+		}
+	}
+}
+
 func TestApply_ConcurrentBaseMove(t *testing.T) {
 	fx := fixture.New(t, fixture.Spec{
 		Modules: []fixture.ModuleSpec{

--- a/internal/propagate/plan.go
+++ b/internal/propagate/plan.go
@@ -4,6 +4,7 @@ package propagate
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -357,9 +358,13 @@ func currentBranch(root string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
+// ErrNoRemoteRef is returned by GetRemoteRefSHA when the remote exists
+// but has no such ref (e.g. the branch hasn't been pushed yet).
+var ErrNoRemoteRef = errors.New("remote has no such ref")
+
 // GetRemoteRefSHA returns the SHA of ref on remote via `git ls-remote`.
-// ref is a full ref (e.g. "refs/heads/main"). Returns an error if the
-// remote has no such ref.
+// ref is a full ref (e.g. "refs/heads/main"). Returns ErrNoRemoteRef if
+// the remote reachable but has no such ref.
 func GetRemoteRefSHA(root, remote, ref string) (string, error) {
 	out, err := shellGit(root, "ls-remote", remote, ref)
 	if err != nil {
@@ -367,7 +372,7 @@ func GetRemoteRefSHA(root, remote, ref string) (string, error) {
 	}
 	line := strings.TrimSpace(out)
 	if line == "" {
-		return "", fmt.Errorf("remote %q has no ref %q", remote, ref)
+		return "", fmt.Errorf("%w: %s %s", ErrNoRemoteRef, remote, ref)
 	}
 	// First line, first column.
 	if nl := strings.IndexByte(line, '\n'); nl >= 0 {

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -5,6 +5,7 @@
 package release
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -39,12 +40,42 @@ type Options struct {
 // override via opts.Bumps), builds the propagation plan, and writes it
 // to stdout. A nil plan with nil error means "nothing to release."
 func Plan(ws *workspace.Workspace, opts Options, stdout io.Writer) (*propagate.Plan, error) {
-	directs, err := propagate.DirectFromReplaces(ws)
+	replaceDirects, err := propagate.DirectFromReplaces(ws)
 	if err != nil {
 		return nil, fmt.Errorf("detect affected modules: %w", err)
 	}
+
+	// The direct set is the union of two sources:
+	//   1. Modules with incoming workspace-local `replace` directives
+	//      (auto-detected — some in-tree consumer is exercising this
+	//      module's latest code, so a release propagates the cascade).
+	//   2. Modules explicitly named via `--bump <module>=<kind>` with a
+	//      non-Skip kind (user intent to release, even if no in-tree
+	//      consumer exists — e.g. a library published for external use).
+	// This keeps "derive don't declare" as the default while matching
+	// Go's reality that a module is releasable regardless of whether
+	// anything in the same repo happens to depend on it.
+	seen := map[string]bool{}
+	directs := make([]string, 0, len(replaceDirects))
+	for _, d := range replaceDirects {
+		if !seen[d] {
+			seen[d] = true
+			directs = append(directs, d)
+		}
+	}
+	for mp, k := range opts.Bumps {
+		if k == bump.Skip || k == bump.None {
+			continue
+		}
+		if !seen[mp] {
+			seen[mp] = true
+			directs = append(directs, mp)
+		}
+	}
+	sort.Strings(directs)
+
 	if len(directs) == 0 {
-		fmt.Fprintln(stdout, "no modules have workspace-local `replace` directives; nothing to release.")
+		fmt.Fprintln(stdout, "no modules have workspace-local `replace` directives and no `--bump` overrides; nothing to release.")
 		return nil, nil
 	}
 
@@ -76,11 +107,19 @@ func Plan(ws *workspace.Workspace, opts Options, stdout io.Writer) (*propagate.P
 		}
 		ref := "refs/heads/" + branch
 		sha, err := propagate.GetRemoteRefSHA(ws.Root, opts.Remote, ref)
-		if err != nil {
+		switch {
+		case errors.Is(err, propagate.ErrNoRemoteRef):
+			// Fresh branch not yet on remote — no base to race with.
+			// Apply will push normally (no lease) and git's own non-ff
+			// rejection still blocks the race if someone creates the
+			// branch in the meantime.
+			popts.BaseRef = ref
+		case err != nil:
 			return nil, fmt.Errorf("read %s %s: %w", opts.Remote, ref, err)
+		default:
+			popts.BaseRef = ref
+			popts.BaseSHA = sha
 		}
-		popts.BaseRef = ref
-		popts.BaseSHA = sha
 	}
 
 	plan, err := propagate.NewPlanForModules(ws, directs, popts)

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -125,6 +125,71 @@ func TestPlan_noAffectedReturnsNil(t *testing.T) {
 	}
 }
 
+// TestPlan_bumpAddsDirectWithoutReplace covers the "publish a library
+// that nothing in-tree consumes" path: no replace directive points at
+// the module, but the user asked for it explicitly via --bump. The
+// module should be treated as direct-affected.
+func TestPlan_bumpAddsDirectWithoutReplace(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	gitRun(t, fx.Root, "tag", "modules/storage/v0.1.0")
+	ws, err := workspace.Load(fx.Root)
+	if err != nil {
+		t.Fatalf("workspace.Load: %v", err)
+	}
+
+	var out bytes.Buffer
+	plan, err := Plan(ws, Options{
+		Slug:  "test",
+		Bumps: map[string]bump.Kind{"example.com/mono/storage": bump.Minor},
+	}, &out)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if plan == nil {
+		t.Fatalf("expected plan; got nil. stdout: %s", out.String())
+	}
+	var found bool
+	for _, e := range plan.Entries {
+		if e.ModulePath == "example.com/mono/storage" {
+			found = true
+			if e.NewVersion != "v0.2.0" {
+				t.Errorf("storage NewVersion = %s, want v0.2.0", e.NewVersion)
+			}
+			if e.Kind != bump.Minor {
+				t.Errorf("storage Kind = %v, want Minor", e.Kind)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("storage missing from plan entries: %+v", plan.Entries)
+	}
+}
+
+// TestPlan_skipBumpDoesNotAddDirect ensures that --bump foo=skip on a
+// module with no replace does NOT add it to the direct set (Skip means
+// "don't release", not "add and then skip").
+func TestPlan_skipBumpDoesNotAddDirect(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	gitRun(t, fx.Root, "tag", "modules/storage/v0.1.0")
+	ws, _ := workspace.Load(fx.Root)
+
+	var out bytes.Buffer
+	plan, err := Plan(ws, Options{
+		Slug:  "test",
+		Bumps: map[string]bump.Kind{"example.com/mono/storage": bump.Skip},
+	}, &out)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if plan != nil {
+		t.Errorf("expected nil plan (skip of lone module = nothing to release); got %+v", plan)
+	}
+}
+
 func TestConfirmProceed(t *testing.T) {
 	cases := map[string]bool{
 		"y\n":   true,


### PR DESCRIPTION
## Summary

Three related fixes that together green the integration suite. Every integration run since [#32](https://github.com/matt0x6F/monoco/pull/32) (2026-04-20) has failed; [#33](https://github.com/matt0x6F/monoco/pull/33)'s bootstrap test has been broken since it landed.

- **Base-move guard handles fresh branches** — `ls-remote` on an unpushed branch no longer aborts release. Exports `ErrNoRemoteRef`; release treats missing-ref as \"no base to race with\" and pushes without a lease. Git's own non-ff rejection still covers the race.
- **Explicit `--bump` can add a module to the direct set** — the direct set is now the union of replace-derived modules and any module explicitly named via `--bump <mp>=<kind>` with a non-Skip kind. Matches Go's reality that a module is releasable regardless of in-tree consumers (most OSS Go libraries have none).
- **Empty release commits are skipped** — bootstrap releases with no cascade produce zero go.mod rewrites, so there's nothing to commit. Check `git diff --cached --quiet` after staging; if clean, tag the existing HEAD.

## Why

[#32](https://github.com/matt0x6F/monoco/pull/32) closed a real concurrent-push race but assumed `origin/<branch>` already existed, which breaks first-release flows (and every integration test, which creates a fresh `test/<runID>` branch per run). [#33](https://github.com/matt0x6F/monoco/pull/33) added coverage for bootstrap-first-tag but exercised a workflow the `replace`-only rule didn't support. Both compounded to fail all 6 release-path integration tests on CI.

## Design notes

- For the bump-union change: [CLAUDE.md](CLAUDE.md) §6 warns against configuration that introduces new mechanisms. `--bump` already existed as an override for kind; letting it also imply direct-add is a semantic extension of an existing flag, not a new concept. Considered alternatives: requiring a dummy consumer with a `replace` (rejected — bad UX for genuine leaf libraries), or a separate `--release <mp>` flag (rejected — doubles the surface area).
- For empty commits: `commit --allow-empty` was considered and rejected. The release commit exists to carry go.mod rewrites; an empty one is ceremonial noise and makes `git log` harder to read. Tags point at the user's own commit that introduced the module — arguably more correct.

## Test plan

- [x] `TestPlan_bumpAddsDirectWithoutReplace` — lone module + `--bump=minor` lands at v0.2.0.
- [x] `TestPlan_skipBumpDoesNotAddDirect` — pins Skip/None exclusion from the add path.
- [x] `TestApply_loneModuleSkipsReleaseCommit` — HEAD doesn't advance, tags land on pre-apply commit.
- [x] `go test ./...` — full unit suite green.
- [x] `go test -tags=integration ./test/integration/...` — all 8 scenarios pass locally against the real test repo.