### PR TITLE
feat(tasks): forward `--` args to task commands (#40)

### DIFF
--- a/cmd/monoco/main.go
+++ b/cmd/monoco/main.go
@@ -230,6 +230,9 @@ func cmdTask(root string, args []string, taskName string, defaultCommand []strin
 	if override := cfg.TaskCommand(taskName); override != nil {
 		command = override
 	}
+	if extra := fs.Args(); len(extra) > 0 {
+		command = append(append([]string{}, command...), extra...)
+	}
 	ws, err := workspace.LoadWithConfig(root, cfg)
 	if err != nil {
 		fatal(err)

--- a/cmd/monoco/main_test.go
+++ b/cmd/monoco/main_test.go
@@ -222,6 +222,24 @@ func TestCLI_taskOverrideFromManifest(t *testing.T) {
 	}
 }
 
+func TestCLI_taskPassthroughArgs(t *testing.T) {
+	bin := buildCLI(t)
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	// Override `test` with echo so the passthrough args land in stdout
+	// verbatim. Verifies that `--` args append to a manifest-overridden
+	// base command (the code path is unified with the default-command case).
+	manifest := "version: 1\ntasks:\n  test:\n    command: [\"/bin/echo\", \"BASE\"]\n"
+	if err := os.WriteFile(filepath.Join(fx.Root, "monoco.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := runCLI(t, bin, fx.Root, "test", "--all", "--", "MARKER_PASSTHROUGH", "-count=1")
+	if !strings.Contains(out, "BASE MARKER_PASSTHROUGH -count=1") {
+		t.Errorf("passthrough args not appended; output:\n%s", out)
+	}
+}
+
 func buildCLI(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- Append tokens after `--` on the CLI to whatever command `monoco test|build|lint|generate` runs, whether that's the built-in default or a `monoco.yaml` override.
- Example: `monoco test --since origin/main -- -count=1 -race -timeout=5m` now forwards those three flags to each affected module's `go test`.

## Why

Fixes #40. Users previously had to write a full `tasks.test.command` entry in `monoco.yaml` just to tack on a flag, duplicating the built-in default. CLAUDE.md principle #6 (convention beats configuration) — `--` is the standard Unix separator and matches how `go test`/`go run` themselves work, so no new vocabulary needed.

## Implementation

Go's `flag` package already stops parsing at `--` and leaves the remainder in `fs.Args()`. `cmdTask` now consults `fs.Args()` after resolving the base command (default or override) and appends to a fresh slice, avoiding any mutation of the shared default/override slices.

## Test plan

- [x] `go test ./cmd/monoco/... -run TestCLI_taskPassthroughArgs` — new test asserts `BASE MARKER_PASSTHROUGH -count=1` round-trips through an echo-overridden task.
- [x] `go test ./cmd/monoco/... -run TestCLI_taskOverrideFromManifest` — existing override test still passes (unchanged code path).
- [x] `go test ./...` — full suite green.