### PR TITLE
fix(init): support single-root-module repos (#39)

### DIFF
--- a/cmd/monoco/main.go
+++ b/cmd/monoco/main.go
@@ -181,9 +181,6 @@ func discoverModules(root string) ([]string, error) {
 			return nil
 		}
 		dir := filepath.Dir(path)
-		if dir == root {
-			return nil
-		}
 		rel, err := filepath.Rel(root, dir)
 		if err != nil {
 			return err
@@ -198,6 +195,10 @@ func writeGoWork(root string, dirs []string) error {
 	var b strings.Builder
 	b.WriteString("go 1.22\n\nuse (\n")
 	for _, d := range dirs {
+		if d == "." {
+			b.WriteString("\t.\n")
+			continue
+		}
 		fmt.Fprintf(&b, "\t./%s\n", d)
 	}
 	b.WriteString(")\n")

--- a/cmd/monoco/main_test.go
+++ b/cmd/monoco/main_test.go
@@ -174,6 +174,33 @@ func TestCLI_init_writesStubManifest(t *testing.T) {
 	}
 }
 
+func TestCLI_init_singleRootModule(t *testing.T) {
+	bin := buildCLI(t)
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/solo\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(root, "solo.go"), "package solo\n\nfunc Hello() string { return \"hi\" }\n")
+	runT(t, root, "git", "init", "-q", "-b", "main")
+	runT(t, root, "git", "config", "user.email", "t@example.com")
+	runT(t, root, "git", "config", "user.name", "t")
+	runT(t, root, "git", "add", "-A")
+	runT(t, root, "git", "commit", "-q", "-m", "init")
+
+	runCLI(t, bin, root, "init")
+
+	workBytes, err := os.ReadFile(filepath.Join(root, "go.work"))
+	if err != nil {
+		t.Fatalf("read go.work: %v", err)
+	}
+	if !strings.Contains(string(workBytes), "\n\t.\n") {
+		t.Errorf("go.work missing root use entry; contents:\n%s", workBytes)
+	}
+
+	// Downstream command must load the workspace and see the root module.
+	out := runCLI(t, bin, root, "affected", "--since", "HEAD")
+	_ = out // an empty diff is fine; success == no "empty workspace" / "no such file" error
+}
+
 func TestCLI_excludedModuleIgnoredByAffected(t *testing.T) {
 	bin := buildCLI(t)
 	fx := fixture.New(t, fixture.Spec{


### PR DESCRIPTION
## Summary
- `discoverModules` now includes the repo-root `go.mod` instead of skipping it, so `monoco init` produces a non-empty `go.work` in single-module repos.
- `writeGoWork` emits a bare `.` entry (`use ( . )`) rather than `./.` — idiomatic and parses cleanly via `modfile.ParseWork`.
- New `TestCLI_init_singleRootModule` covers the case end-to-end: init + a follow-up `affected` call against a root-only repo.

## Why
Closes #39. The root-skip was a correct invariant for multi-module repos (where the root has no `go.mod`) but it wrongly overrode the single-module case, producing an empty workspace and making every downstream command a no-op. This also unblocks dogfooding monoco on itself.

## Scoping
- #1 Derive, don't declare — still reading `go.mod` from disk.
- #4 Leave-able — `go.work` with `use .` is standard Go.
- #6 Convention beats configuration — zero-config init for single-module repos.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] New `TestCLI_init_singleRootModule` asserts `use .` ends up in `go.work` and a downstream command loads the workspace without error.