### PR TITLE
test(propagate): cover Verify edge cases

### DIFF
--- a/internal/propagate/verify_test.go
+++ b/internal/propagate/verify_test.go
@@ -3,7 +3,9 @@ package propagate
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -104,5 +106,92 @@ func TestVerify_parallelAbortsOnFirstFailure(t *testing.T) {
 		n, elapsed, modulesPerSec)
 	if modulesPerSec < 1.0 {
 		t.Errorf("effective throughput %.2f modules/s below 1 modules/s threshold", modulesPerSec)
+	}
+}
+
+// TestVerify_overwritesPreexistingAlt ensures that a stale go.verify.mod
+// / go.verify.sum left from a prior aborted run is overwritten and then
+// cleaned up on success.
+func TestVerify_overwritesPreexistingAlt(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	storageDir := filepath.Join(fx.Root, "modules/storage")
+	altMod := filepath.Join(storageDir, "go.verify.mod")
+	altSum := filepath.Join(storageDir, "go.verify.sum")
+	if err := os.WriteFile(altMod, []byte("garbage bytes\n"), 0o644); err != nil {
+		t.Fatalf("pre-write alt mod: %v", err)
+	}
+	if err := os.WriteFile(altSum, []byte("garbage\n"), 0o644); err != nil {
+		t.Fatalf("pre-write alt sum: %v", err)
+	}
+
+	ws, _ := workspace.Load(fx.Root)
+	if err := Verify(context.Background(), ws, []string{"example.com/mono/storage"}); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	if _, err := os.Stat(altMod); !os.IsNotExist(err) {
+		t.Errorf("go.verify.mod still present after Verify: %v", err)
+	}
+	if _, err := os.Stat(altSum); !os.IsNotExist(err) {
+		t.Errorf("go.verify.sum still present after Verify: %v", err)
+	}
+}
+
+// TestVerify_cleansUpOnFailure confirms that when a build fails the alt
+// modfile/sum are still removed — the defer must fire before Verify
+// returns the error.
+func TestVerify_cleansUpOnFailure(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	storageDir := filepath.Join(fx.Root, "modules/storage")
+	writeFile(t, filepath.Join(storageDir, "storage.go"),
+		"package storage\n\nfunc Broken() string { return doesNotExist() }\n")
+	run(t, fx.Root, "git", "add", "-A")
+	run(t, fx.Root, "git", "commit", "-m", "break storage")
+
+	ws, _ := workspace.Load(fx.Root)
+	if err := Verify(context.Background(), ws, []string{"example.com/mono/storage"}); err == nil {
+		t.Fatal("Verify succeeded on broken source")
+	}
+	for _, f := range []string{"go.verify.mod", "go.verify.sum"} {
+		p := filepath.Join(storageDir, f)
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("%s still present after failed Verify: %v", f, err)
+		}
+	}
+}
+
+// TestVerify_unreadableGoMod ensures read failures surface with a
+// path-bearing error.
+func TestVerify_unreadableGoMod(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0 unreliable on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses chmod")
+	}
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{{Name: "storage"}},
+	})
+	goMod := filepath.Join(fx.Root, "modules/storage/go.mod")
+	origMode, err := os.Stat(goMod)
+	if err != nil {
+		t.Fatalf("stat go.mod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(goMod, origMode.Mode().Perm()) })
+
+	ws, _ := workspace.Load(fx.Root)
+	if err := os.Chmod(goMod, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	err = Verify(context.Background(), ws, []string{"example.com/mono/storage"})
+	if err == nil {
+		t.Fatal("Verify succeeded on unreadable go.mod")
+	}
+	if !strings.Contains(err.Error(), "go.mod") {
+		t.Errorf("error does not mention go.mod path: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
Three new tests in [internal/propagate/verify_test.go](internal/propagate/verify_test.go):
- `TestVerify_overwritesPreexistingAlt` — stale `go.verify.mod` / `go.verify.sum` from an aborted prior run are overwritten and cleaned.
- `TestVerify_cleansUpOnFailure` — deferred `os.Remove` still fires when the build fails.
- `TestVerify_unreadableGoMod` — unreadable `go.mod` surfaces a path-bearing error (skips on Windows / root).

Locks in the current defer-cleanup behavior so future refactors can't silently regress it.

## Test plan
- [x] `go test ./internal/propagate/ -run TestVerify -count=1` passes