### PR TITLE
security(test): route integration token via .netrc only

### DIFF
--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestChooseCloneURL_NoTokenInURL asserts that even when a token is set,
+// chooseCloneURL returns a plain URL — the token travels through the
+// .netrc helper exclusively. Regression guard for the security fix.
+func TestChooseCloneURL_NoTokenInURL(t *testing.T) {
+	token := os.Getenv("MONOCO_TEST_REPO_TOKEN")
+	if token == "" {
+		t.Skip("MONOCO_TEST_REPO_TOKEN not set; nothing to leak")
+	}
+	url, _ := chooseCloneURL()
+	if strings.Contains(url, "@") {
+		t.Errorf("clone URL contains '@' (token embedding?): %q", url)
+	}
+	if strings.Contains(url, token) {
+		t.Errorf("clone URL leaks the token substring")
+	}
+}
+
+// TestSanitizedEnv_PointsHOMEAtNetrcDir asserts that when a token is
+// configured, sanitizedEnv sets HOME to the scratch dir and adds
+// GIT_CONFIG_GLOBAL=/dev/null so the token flows via .netrc only.
+func TestSanitizedEnv_PointsHOMEAtNetrcDir(t *testing.T) {
+	token := os.Getenv("MONOCO_TEST_REPO_TOKEN")
+	if token == "" {
+		t.Skip("MONOCO_TEST_REPO_TOKEN not set")
+	}
+	env := sanitizedEnv()
+	var gotHome, gotCfg bool
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "HOME=") {
+			if gotHome {
+				t.Errorf("duplicate HOME= in env: %v", env)
+			}
+			gotHome = true
+			home := strings.TrimPrefix(kv, "HOME=")
+			netrc := home + "/.netrc"
+			fi, err := os.Stat(netrc)
+			if err != nil {
+				t.Errorf("stat %s: %v", netrc, err)
+				continue
+			}
+			if mode := fi.Mode().Perm(); mode != 0o600 {
+				t.Errorf(".netrc mode = %o, want 0600", mode)
+			}
+		}
+		if strings.HasPrefix(kv, "GIT_CONFIG_GLOBAL=") {
+			gotCfg = true
+		}
+		if strings.Contains(kv, token) && !strings.HasPrefix(kv, "MONOCO_TEST_REPO_TOKEN=") {
+			t.Errorf("env var leaks token: %s", kv)
+		}
+	}
+	if !gotHome {
+		t.Errorf("sanitizedEnv did not set HOME")
+	}
+	if !gotCfg {
+		t.Errorf("sanitizedEnv did not set GIT_CONFIG_GLOBAL")
+	}
+}

--- a/test/integration/harness.go
+++ b/test/integration/harness.go
@@ -47,10 +47,42 @@ const (
 // buildOnce caches the compiled monoco binary across tests in the same
 // `go test` invocation. Build costs ~2s; with 7 scenarios that matters.
 var (
-	buildOnce   sync.Once
-	builtBin    string
-	buildErr    error
+	buildOnce sync.Once
+	builtBin  string
+	buildErr  error
 )
+
+// authHome caches a process-scoped HOME directory containing a .netrc
+// with the token. Every git/go invocation in this package points HOME at
+// this dir so the token flows through git's native credential path
+// instead of being embedded in the clone URL.
+var (
+	authHomeOnce sync.Once
+	authHomeDir  string
+	authHomeErr  error
+)
+
+func netrcAuthHome() (string, error) {
+	authHomeOnce.Do(func() {
+		token := os.Getenv("MONOCO_TEST_REPO_TOKEN")
+		if token == "" {
+			return
+		}
+		dir, err := os.MkdirTemp("", "monoco-auth-home-")
+		if err != nil {
+			authHomeErr = err
+			return
+		}
+		netrc := "machine github.com login x-access-token password " + token + "\n"
+		netrcPath := filepath.Join(dir, ".netrc")
+		if err := os.WriteFile(netrcPath, []byte(netrc), 0o600); err != nil {
+			authHomeErr = err
+			return
+		}
+		authHomeDir = dir
+	})
+	return authHomeDir, authHomeErr
+}
 
 type harness struct {
 	t        *testing.T
@@ -146,17 +178,13 @@ func snapshotRemoteTags(t *testing.T, wt string) map[string]string {
 	return m
 }
 
-// chooseCloneURL returns (url, human-readable note). Prefers HTTPS+token;
-// falls back to SSH URL for local dev.
+// chooseCloneURL returns (url, human-readable note). Prefers HTTPS when
+// MONOCO_TEST_REPO_TOKEN is set (auth flows via a .netrc under a test-
+// scoped HOME — never embedded in the URL); falls back to SSH otherwise.
 func chooseCloneURL() (string, string) {
-	token := os.Getenv("MONOCO_TEST_REPO_TOKEN")
-	if token != "" {
+	if os.Getenv("MONOCO_TEST_REPO_TOKEN") != "" {
 		base := envOr("MONOCO_TEST_REPO_HTTPS", defaultRepoHTTPS)
-		// Bake the token into the clone URL. Because the URL lives
-		// only in the workspace's .git/config inside t.TempDir(), it
-		// is cleaned up automatically when the test ends.
-		withAuth := strings.Replace(base, "https://", "https://x-access-token:"+token+"@", 1)
-		return withAuth, "HTTPS with MONOCO_TEST_REPO_TOKEN"
+		return base, "HTTPS with MONOCO_TEST_REPO_TOKEN (via .netrc)"
 	}
 	ssh := envOr("MONOCO_TEST_REPO_SSH", defaultRepoSSH)
 	return ssh, "SSH (" + ssh + ") — no token provided"
@@ -462,22 +490,33 @@ func runIDNow(t *testing.T) string {
 func todayUTC() string { return time.Now().UTC().Format("2006-01-02") }
 
 // sanitizedEnv strips any git/auth env vars from the parent process
-// that could interfere with our controlled token handling. We do NOT
-// strip GOPATH/GOCACHE because the test binary needs them.
+// that could interfere with our controlled token handling and, when a
+// token is configured, points HOME at a scratch dir holding only a
+// .netrc for github.com. This keeps the token out of clone URLs and
+// out of the working-tree's .git/config.
 func sanitizedEnv() []string {
+	token := os.Getenv("MONOCO_TEST_REPO_TOKEN")
 	var out []string
 	for _, kv := range os.Environ() {
-		if strings.HasPrefix(kv, "GIT_ASKPASS=") || strings.HasPrefix(kv, "SSH_AUTH_SOCK=") {
-			// Keep SSH_AUTH_SOCK when we don't have a token — SSH
-			// fallback path needs it. Strip GIT_ASKPASS always.
-			if strings.HasPrefix(kv, "GIT_ASKPASS=") {
-				continue
-			}
-			if os.Getenv("MONOCO_TEST_REPO_TOKEN") != "" {
-				continue
-			}
+		if strings.HasPrefix(kv, "HOME=") && token != "" {
+			continue
+		}
+		if strings.HasPrefix(kv, "GIT_CONFIG_GLOBAL=") && token != "" {
+			continue
+		}
+		if strings.HasPrefix(kv, "GIT_ASKPASS=") {
+			continue
+		}
+		if strings.HasPrefix(kv, "SSH_AUTH_SOCK=") && token != "" {
+			continue
 		}
 		out = append(out, kv)
+	}
+	if token != "" {
+		home, err := netrcAuthHome()
+		if err == nil && home != "" {
+			out = append(out, "HOME="+home, "GIT_CONFIG_GLOBAL=/dev/null")
+		}
 	}
 	return out
 }


### PR DESCRIPTION
## Summary
Stops embedding \`MONOCO_TEST_REPO_TOKEN\` in the HTTPS clone URL. The token now flows exclusively through a process-scoped \`.netrc\` under a scratch HOME — so it never lands in the test clone's \`.git/config\` or any URL that could surface in traces.

Changes in [test/integration/harness.go](test/integration/harness.go):
- \`chooseCloneURL\` returns the plain HTTPS URL.
- \`sanitizedEnv\` sets \`HOME=\<tempdir with 0o600 .netrc\>\` and \`GIT_CONFIG_GLOBAL=/dev/null\` when a token is configured.
- New \`auth_test.go\` asserts the URL never contains \`@\` or the token, and the env invariants hold.

## Test plan
- [x] \`go vet -tags=integration ./test/integration/...\`
- [x] Skip-path auth tests pass without a token
- [ ] Run \`go test -tags=integration ./test/integration/...\` with \`MONOCO_TEST_REPO_TOKEN\` set; inspect \`.git/config\` — no token substring.
- [ ] Run with \`GIT_TRACE=1\`; grep trace for the token literal — must not appear.