### PR TITLE
refactor(internal): extract shared gitx git helper

### DIFF
--- a/internal/gitgraph/gitgraph.go
+++ b/internal/gitgraph/gitgraph.go
@@ -3,12 +3,11 @@
 package gitgraph
 
 import (
-	"bytes"
-	"fmt"
-	"os/exec"
+	"context"
 	"sort"
 	"strings"
 
+	"github.com/matt0x6f/monoco/internal/gitx"
 	"golang.org/x/mod/semver"
 )
 
@@ -22,7 +21,7 @@ type Commit struct {
 // TouchedFiles returns repo-relative paths of files changed between oldRef
 // and newRef (both inclusive of HEAD side per git diff --name-only).
 func TouchedFiles(root, oldRef, newRef string) ([]string, error) {
-	out, err := git(root, "diff", "--name-only", oldRef, newRef)
+	out, err := gitx.Run(context.Background(), root, "diff", "--name-only", oldRef, newRef)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +47,7 @@ func CommitsInRange(root, oldRef, newRef, path string) ([]Commit, error) {
 	if path != "" {
 		args = append(args, "--", path)
 	}
-	out, err := git(root, args...)
+	out, err := gitx.Run(context.Background(), root, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +73,7 @@ func CommitsInRange(root, oldRef, newRef, path string) ([]Commit, error) {
 // LatestTagForModule returns the highest-semver tag for a module whose
 // tag-prefix is modulePrefix (e.g. "modules/storage"). Returns "" if none.
 func LatestTagForModule(root, modulePrefix string) (string, error) {
-	out, err := git(root, "tag", "--list", modulePrefix+"/v*")
+	out, err := gitx.Run(context.Background(), root, "tag", "--list", modulePrefix+"/v*")
 	if err != nil {
 		return "", err
 	}
@@ -98,15 +97,4 @@ func LatestTagForModule(root, modulePrefix string) (string, error) {
 		return semver.Compare(versions[i], versions[j]) < 0
 	})
 	return versions[len(versions)-1], nil
-}
-
-func git(root string, args ...string) (string, error) {
-	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("git %v: %w: %s", args, err, stderr.String())
-	}
-	return stdout.String(), nil
 }

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -1,0 +1,29 @@
+// Package gitx provides a single shared helper for invoking the git CLI.
+// It exists so gitgraph, propagate, and release all produce identical
+// error shapes and respect ctx cancellation uniformly.
+package gitx
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// Run executes `git -C root <args...>` and returns trimmed stdout.
+// A nil ctx is treated as context.Background(). On non-zero exit the
+// returned error carries the git args, the underlying err, and stderr.
+func Run(ctx context.Context, root string, args ...string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	full := append([]string{"-C", root}, args...)
+	cmd := exec.CommandContext(ctx, "git", full...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git %v: %w: %s", args, err, stderr.String())
+	}
+	return stdout.String(), nil
+}

--- a/internal/gitx/gitx_test.go
+++ b/internal/gitx/gitx_test.go
@@ -1,0 +1,81 @@
+package gitx
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+		{"commit", "--allow-empty", "-m", "init"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	return dir
+}
+
+func TestRun_StdoutTrimmable(t *testing.T) {
+	dir := initRepo(t)
+	out, err := Run(context.Background(), dir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatalf("expected a SHA, got %q", out)
+	}
+}
+
+func TestRun_ErrorCarriesStderr(t *testing.T) {
+	dir := initRepo(t)
+	_, err := Run(context.Background(), dir, "no-such-subcommand")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no-such-subcommand") {
+		t.Fatalf("error should name the failing args: %v", err)
+	}
+}
+
+func TestRun_CtxCancelKillsSubprocess(t *testing.T) {
+	dir := initRepo(t)
+	// Use git's wait-if-busy via a bogus --exec-path trick? Simpler:
+	// run `git gc --aggressive` on a tiny repo won't block long. Use a
+	// sleep-proxy by invoking a hook. Simplest: cancel before calling Run
+	// and confirm the cancellation propagates as an error.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancel()
+	// Ensure ctx is already expired.
+	time.Sleep(5 * time.Millisecond)
+	_, err := Run(ctx, dir, "log")
+	if err == nil {
+		t.Fatal("expected error from canceled ctx")
+	}
+}
+
+func TestRun_HonorsRootFlag(t *testing.T) {
+	dir := initRepo(t)
+	// Create a nested dir that is NOT a git repo; -C should point us at dir.
+	nested := filepath.Join(dir, "sub")
+	if err := exec.Command("mkdir", nested).Run(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := Run(context.Background(), dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(strings.TrimSpace(out), filepath.Base(dir)) {
+		t.Fatalf("expected toplevel under %q, got %q", dir, out)
+	}
+}

--- a/internal/propagate/apply.go
+++ b/internal/propagate/apply.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/matt0x6f/monoco/internal/gitx"
 	"github.com/matt0x6f/monoco/internal/propagate/importrewrite"
 	"github.com/matt0x6f/monoco/internal/workspace"
 	"golang.org/x/mod/modfile"
@@ -64,7 +65,7 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 	}
 
 	// Snapshot HEAD for rollback.
-	oldHeadOut, err := shellGit(ws.Root, "rev-parse", "HEAD")
+	oldHeadOut, err := gitx.Run(context.Background(), ws.Root, "rev-parse", "HEAD")
 	if err != nil {
 		return nil, err
 	}
@@ -74,10 +75,10 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 	var createdTags []string
 	rollback := func() {
 		for _, t := range createdTags {
-			_, _ = shellGit(ws.Root, "tag", "-d", t)
+			_, _ = gitx.Run(context.Background(), ws.Root, "tag", "-d", t)
 		}
 		// reset --hard to oldHead: discards release commit and restores working tree.
-		_, _ = shellGit(ws.Root, "reset", "--hard", oldHead)
+		_, _ = gitx.Run(context.Background(), ws.Root, "reset", "--hard", oldHead)
 	}
 
 	// 1. Rewrite go.mod + go.sum in topo order.
@@ -90,7 +91,7 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 	// anything on disk). Bootstrap releases of modules with no in-tree
 	// consumers produce zero go.mod rewrites, so there's nothing to
 	// commit — we tag the existing HEAD instead.
-	if _, err := shellGit(ws.Root, "add", "-A"); err != nil {
+	if _, err := gitx.Run(context.Background(), ws.Root, "add", "-A"); err != nil {
 		rollback()
 		return nil, err
 	}
@@ -100,7 +101,7 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 		return nil, err
 	}
 	if hasStaged {
-		if _, err := shellGit(ws.Root, "commit", "-m", plan.CommitMsg); err != nil {
+		if _, err := gitx.Run(context.Background(), ws.Root, "commit", "-m", plan.CommitMsg); err != nil {
 			rollback()
 			return nil, fmt.Errorf("create release commit: %w", err)
 		}
@@ -122,7 +123,7 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 		return nil, fmt.Errorf("verify: %w", err)
 	}
 
-	releaseSHAOut, err := shellGit(ws.Root, "rev-parse", "HEAD")
+	releaseSHAOut, err := gitx.Run(context.Background(), ws.Root, "rev-parse", "HEAD")
 	if err != nil {
 		rollback()
 		return nil, err
@@ -135,14 +136,14 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 			createdTags = append(createdTags, e.TagName)
 			continue
 		}
-		if _, err := shellGit(ws.Root, "tag", e.TagName, releaseSHA); err != nil {
+		if _, err := gitx.Run(context.Background(), ws.Root, "tag", e.TagName, releaseSHA); err != nil {
 			rollback()
 			return nil, fmt.Errorf("tag %s: %w", e.TagName, err)
 		}
 		createdTags = append(createdTags, e.TagName)
 	}
 	if !tagAlreadyAt(ws.Root, plan.TrainTag, releaseSHA) {
-		if _, err := shellGit(ws.Root, "tag", plan.TrainTag, releaseSHA); err != nil {
+		if _, err := gitx.Run(context.Background(), ws.Root, "tag", plan.TrainTag, releaseSHA); err != nil {
 			rollback()
 			return nil, fmt.Errorf("tag %s: %w", plan.TrainTag, err)
 		}
@@ -433,7 +434,7 @@ func mergeGoSum(goSumPath string, adds []string) error {
 }
 
 func requireCleanWorkingTree(root string) error {
-	out, err := shellGit(root, "status", "--porcelain")
+	out, err := gitx.Run(context.Background(), root, "status", "--porcelain")
 	if err != nil {
 		return fmt.Errorf("git status: %w", err)
 	}
@@ -457,7 +458,7 @@ func atomicPush(root, remote, branch string, tags []string, leaseSHA string) err
 	}
 
 	if leaseSHA == "" {
-		_, err := shellGit(root, build(false)...)
+		_, err := gitx.Run(context.Background(), root, build(false)...)
 		return err
 	}
 
@@ -466,14 +467,14 @@ func atomicPush(root, remote, branch string, tags []string, leaseSHA string) err
 	// to a plain atomic push: a non-fast-forward would still be
 	// rejected, and the preflight SHA check already caught the common
 	// race. The fallback keeps monoco usable on strict GitHub orgs.
-	_, err := shellGit(root, build(true)...)
+	_, err := gitx.Run(context.Background(), root, build(true)...)
 	if err == nil {
 		return nil
 	}
 	if !isProtectedBranchLeaseReject(err) {
 		return err
 	}
-	_, err2 := shellGit(root, build(false)...)
+	_, err2 := gitx.Run(context.Background(), root, build(false)...)
 	return err2
 }
 
@@ -512,7 +513,7 @@ func hasStagedChanges(root string) (bool, error) {
 }
 
 func tagAlreadyAt(root, tag, sha string) bool {
-	existing, err := shellGit(root, "rev-list", "-n", "1", tag)
+	existing, err := gitx.Run(context.Background(), root, "rev-list", "-n", "1", tag)
 	if err != nil {
 		return false
 	}

--- a/internal/propagate/apply.go
+++ b/internal/propagate/apply.go
@@ -3,7 +3,9 @@ package propagate
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -73,18 +75,30 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 
 	// Track tags we create locally so we can roll them back.
 	var createdTags []string
-	rollback := func() {
+	rollback := func() error {
+		var errs []error
 		for _, t := range createdTags {
-			_, _ = gitx.Run(context.Background(), ws.Root, "tag", "-d", t)
+			if _, err := gitx.Run(context.Background(), ws.Root, "tag", "-d", t); err != nil {
+				log.Printf("rollback: delete tag %s: %v", t, err)
+				errs = append(errs, fmt.Errorf("delete tag %s: %w", t, err))
+			}
 		}
-		// reset --hard to oldHead: discards release commit and restores working tree.
-		_, _ = gitx.Run(context.Background(), ws.Root, "reset", "--hard", oldHead)
+		if _, err := gitx.Run(context.Background(), ws.Root, "reset", "--hard", oldHead); err != nil {
+			log.Printf("rollback: reset --hard %s: %v", oldHead, err)
+			errs = append(errs, fmt.Errorf("reset --hard %s: %w", oldHead, err))
+		}
+		return errors.Join(errs...)
+	}
+	failAndRollback := func(orig error) error {
+		if rerr := rollback(); rerr != nil {
+			return fmt.Errorf("%w; rollback also failed: %v", orig, rerr)
+		}
+		return orig
 	}
 
 	// 1. Rewrite go.mod + go.sum in topo order.
 	if err := rewriteGoMods(ws, plan); err != nil {
-		rollback()
-		return nil, fmt.Errorf("rewrite go.mods: %w", err)
+		return nil, failAndRollback(fmt.Errorf("rewrite go.mods: %w", err))
 	}
 
 	// 2. Create the release commit (only if rewrites actually changed
@@ -92,18 +106,15 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 	// consumers produce zero go.mod rewrites, so there's nothing to
 	// commit — we tag the existing HEAD instead.
 	if _, err := gitx.Run(context.Background(), ws.Root, "add", "-A"); err != nil {
-		rollback()
-		return nil, err
+		return nil, failAndRollback(err)
 	}
 	hasStaged, err := hasStagedChanges(ws.Root)
 	if err != nil {
-		rollback()
-		return nil, err
+		return nil, failAndRollback(err)
 	}
 	if hasStaged {
 		if _, err := gitx.Run(context.Background(), ws.Root, "commit", "-m", plan.CommitMsg); err != nil {
-			rollback()
-			return nil, fmt.Errorf("create release commit: %w", err)
+			return nil, failAndRollback(fmt.Errorf("create release commit: %w", err))
 		}
 	}
 
@@ -111,22 +122,19 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 	// rewrite module paths (including any /vN majors) are visible.
 	verifyWS, err := workspace.Load(ws.Root)
 	if err != nil {
-		rollback()
-		return nil, fmt.Errorf("reload workspace for verify: %w", err)
+		return nil, failAndRollback(fmt.Errorf("reload workspace for verify: %w", err))
 	}
 	paths := make([]string, 0, len(plan.Entries))
 	for _, e := range plan.Entries {
 		paths = append(paths, targetPath(e))
 	}
 	if err := Verify(ctx, verifyWS, paths); err != nil {
-		rollback()
-		return nil, fmt.Errorf("verify: %w", err)
+		return nil, failAndRollback(fmt.Errorf("verify: %w", err))
 	}
 
 	releaseSHAOut, err := gitx.Run(context.Background(), ws.Root, "rev-parse", "HEAD")
 	if err != nil {
-		rollback()
-		return nil, err
+		return nil, failAndRollback(err)
 	}
 	releaseSHA := trim(releaseSHAOut)
 
@@ -137,15 +145,13 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 			continue
 		}
 		if _, err := gitx.Run(context.Background(), ws.Root, "tag", e.TagName, releaseSHA); err != nil {
-			rollback()
-			return nil, fmt.Errorf("tag %s: %w", e.TagName, err)
+			return nil, failAndRollback(fmt.Errorf("tag %s: %w", e.TagName, err))
 		}
 		createdTags = append(createdTags, e.TagName)
 	}
 	if !tagAlreadyAt(ws.Root, plan.TrainTag, releaseSHA) {
 		if _, err := gitx.Run(context.Background(), ws.Root, "tag", plan.TrainTag, releaseSHA); err != nil {
-			rollback()
-			return nil, fmt.Errorf("tag %s: %w", plan.TrainTag, err)
+			return nil, failAndRollback(fmt.Errorf("tag %s: %w", plan.TrainTag, err))
 		}
 	}
 	createdTags = append(createdTags, plan.TrainTag)

--- a/internal/propagate/apply_rollback_test.go
+++ b/internal/propagate/apply_rollback_test.go
@@ -1,0 +1,87 @@
+package propagate
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/matt0x6f/monoco/internal/bump"
+	"github.com/matt0x6f/monoco/internal/fixture"
+	"github.com/matt0x6f/monoco/internal/workspace"
+)
+
+// TestApply_rollbackFailureSurfaced forces rollback to fail during Verify
+// (by corrupting go.sum AND making the .git dir read-only so tag-delete
+// and reset --hard both error) and asserts the returned error reports
+// both the original failure and the rollback failure.
+func TestApply_rollbackFailureSurfaced(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based rollback failure is POSIX-only")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses chmod")
+	}
+
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "api", DependsOn: []string{"storage"}},
+		},
+	})
+	run(t, fx.Root, "git", "tag", "modules/storage/v0.1.0")
+	run(t, fx.Root, "git", "tag", "modules/api/v0.1.0")
+
+	// Introduce broken source so Verify fails AFTER the commit + tags are
+	// created — this is the path that exercises the full rollback closure.
+	writeFile(t, filepath.Join(fx.Root, "modules/api/api.go"),
+		"package api\n\nimport \"example.com/mono/storage\"\n\nfunc Broken() string { return storage.DoesNotExist() }\n")
+	run(t, fx.Root, "git", "add", "-A")
+	run(t, fx.Root, "git", "commit", "-m", "api: intentionally broken")
+
+	ws, _ := workspace.Load(fx.Root)
+	plan, err := NewPlanForModules(ws, []string{"example.com/mono/storage"}, Options{
+		Slug:  "rollback",
+		Bumps: map[string]bump.Kind{"example.com/mono/storage": bump.Minor},
+	})
+	if err != nil {
+		t.Fatalf("NewPlanForModules: %v", err)
+	}
+
+	// Make .git read-only so rollback's `tag -d` and `reset --hard` both
+	// error. Restore in cleanup so t.TempDir can clean up.
+	gitDir := filepath.Join(fx.Root, ".git")
+	origMode := mustStatMode(t, gitDir)
+	t.Cleanup(func() { _ = os.Chmod(gitDir, origMode) })
+
+	// Defer chmod until just before Apply so fixture setup commits succeed.
+	if err := os.Chmod(gitDir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	_, err = Apply(ws, plan, ApplyOptions{})
+	if err == nil {
+		t.Fatal("expected Apply to fail")
+	}
+
+	msg := err.Error()
+	// The original failure must surface (any git error from the first
+	// step that tripped once .git went read-only).
+	if !strings.Contains(msg, "Permission denied") {
+		t.Errorf("error missing original cause: %v", err)
+	}
+	// And so must the rollback failure.
+	if !strings.Contains(msg, "rollback also failed") {
+		t.Errorf("error missing rollback cause: %v", err)
+	}
+}
+
+func mustStatMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return fi.Mode().Perm()
+}

--- a/internal/propagate/plan.go
+++ b/internal/propagate/plan.go
@@ -3,10 +3,9 @@
 package propagate
 
 import (
-	"bytes"
+	"context"
 	"errors"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/matt0x6f/monoco/internal/bump"
 	"github.com/matt0x6f/monoco/internal/gitgraph"
+	"github.com/matt0x6f/monoco/internal/gitx"
 	"github.com/matt0x6f/monoco/internal/workspace"
 	"golang.org/x/mod/semver"
 )
@@ -351,7 +351,7 @@ func CurrentBranch(root string) (string, error) {
 }
 
 func currentBranch(root string) (string, error) {
-	out, err := shellGit(root, "symbolic-ref", "--short", "HEAD")
+	out, err := gitx.Run(context.Background(), root, "symbolic-ref", "--short", "HEAD")
 	if err != nil {
 		return "", err
 	}
@@ -366,7 +366,7 @@ var ErrNoRemoteRef = errors.New("remote has no such ref")
 // ref is a full ref (e.g. "refs/heads/main"). Returns ErrNoRemoteRef if
 // the remote reachable but has no such ref.
 func GetRemoteRefSHA(root, remote, ref string) (string, error) {
-	out, err := shellGit(root, "ls-remote", remote, ref)
+	out, err := gitx.Run(context.Background(), root, "ls-remote", remote, ref)
 	if err != nil {
 		return "", err
 	}
@@ -406,15 +406,4 @@ func normalizeRelDir(p string) string {
 	p = filepath.ToSlash(filepath.Clean(p))
 	p = strings.TrimPrefix(p, "./")
 	return p
-}
-
-func shellGit(root string, args ...string) (string, error) {
-	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("git %v: %w: %s", args, err, stderr.String())
-	}
-	return stdout.String(), nil
 }

--- a/internal/propagate/plan.go
+++ b/internal/propagate/plan.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -224,13 +225,17 @@ func buildPlan(ws *workspace.Workspace, modules []string, directSet map[string]s
 		mod := ws.Modules[modPath]
 		_, isDirect := directSet[modPath]
 		rel := normalizeRelDir(mod.RelDir)
+		tag := rel + "/" + versions[modPath]
+		if err := validateModuleTag(tag); err != nil {
+			return nil, fmt.Errorf("module %s: %w", modPath, err)
+		}
 		entries = append(entries, Entry{
 			ModulePath:   modPath,
 			RelDir:       rel,
 			OldVersion:   oldVersions[modPath],
 			NewVersion:   versions[modPath],
 			Kind:         bumps[modPath],
-			TagName:      rel + "/" + versions[modPath],
+			TagName:      tag,
 			DirectChange: isDirect,
 			MajorBump:    majorBumps[modPath],
 		})
@@ -249,6 +254,9 @@ func buildPlan(ws *workspace.Workspace, modules []string, directSet map[string]s
 		slug = "release"
 	}
 	train := fmt.Sprintf("train/%s-%s", now.Format("2006-01-02"), slug)
+	if err := validateTrainTag(train); err != nil {
+		return nil, err
+	}
 
 	return &Plan{
 		Root:      ws.Root,
@@ -400,6 +408,36 @@ func sanitizeSlug(s string) string {
 		}
 	}
 	return strings.Trim(b.String(), "-")
+}
+
+// moduleTagRE matches monoco's per-module tag format: a relative module
+// path (Go-identifier-friendly, slash-separated) joined to a strict
+// semver via "/vX.Y.Z" with optional pre-release metadata. It
+// intentionally rejects "+build" metadata (monoco never emits it),
+// traversal sequences, whitespace, and control runes.
+var moduleTagRE = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*/v\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?$`)
+
+// trainTagRE matches train/<yyyy-mm-dd>-<slug>.
+var trainTagRE = regexp.MustCompile(`^train/\d{4}-\d{2}-\d{2}-[a-z0-9._-]+$`)
+
+func validateModuleTag(name string) error {
+	if name == "" {
+		return fmt.Errorf("module tag is empty")
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("module tag %q contains traversal sequence", name)
+	}
+	if !moduleTagRE.MatchString(name) {
+		return fmt.Errorf("module tag %q is not <modulepath>/vX.Y.Z[-pre]", name)
+	}
+	return nil
+}
+
+func validateTrainTag(name string) error {
+	if !trainTagRE.MatchString(name) {
+		return fmt.Errorf("train tag %q is not train/YYYY-MM-DD-<slug>", name)
+	}
+	return nil
 }
 
 func normalizeRelDir(p string) string {

--- a/internal/propagate/tagvalidate_test.go
+++ b/internal/propagate/tagvalidate_test.go
@@ -1,0 +1,52 @@
+package propagate
+
+import "testing"
+
+func TestValidateModuleTag(t *testing.T) {
+	cases := []struct {
+		in    string
+		valid bool
+	}{
+		{"modules/storage/v0.1.0", true},
+		{"modules/api/v1.2.3-rc.1", true},
+		{"v2/modules/api/v2.0.0", true},
+		{"", false},
+		{"../evil/v0.1.0", false},
+		{"modules/..//v0.1.0", false},
+		{"modules/storage/v0.1", false},
+		{"modules/storage/0.1.0", false},
+		{"modules/storage/v0.1.0+build", false},
+		{"modules/store age/v0.1.0", false},
+		{"modules/store\tage/v0.1.0", false},
+		{"modules/store\x00/v0.1.0", false},
+		{"/modules/storage/v0.1.0", false},
+		{"-modules/storage/v0.1.0", false},
+	}
+	for _, tc := range cases {
+		err := validateModuleTag(tc.in)
+		if (err == nil) != tc.valid {
+			t.Errorf("validateModuleTag(%q) err=%v, want valid=%v", tc.in, err, tc.valid)
+		}
+	}
+}
+
+func TestValidateTrainTag(t *testing.T) {
+	cases := []struct {
+		in    string
+		valid bool
+	}{
+		{"train/2026-04-21-release", true},
+		{"train/2026-04-21-feat-foo.bar_baz", true},
+		{"release/2026-04-21-feat", false},
+		{"train/20260421-release", false},
+		{"train/2026-04-21-", false},
+		{"train/2026-04-21-HASUPPER", false},
+		{"train/2026-04-21-with space", false},
+	}
+	for _, tc := range cases {
+		err := validateTrainTag(tc.in)
+		if (err == nil) != tc.valid {
+			t.Errorf("validateTrainTag(%q) err=%v, want valid=%v", tc.in, err, tc.valid)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
\`gitgraph.git()\` and \`propagate.shellGit()\` were two near-identical \`exec.Command(\"git\", \"-C\", root, args...)\` wrappers that returned stdout on success or a wrapped error on failure. Every new subpackage needing to shell out to git would grow a third copy.

Extract one helper: [internal/gitx/gitx.go](internal/gitx/gitx.go).
- \`Run(ctx context.Context, root string, args ...string) (string, error)\`
- Uses \`exec.CommandContext\` so ctx cancellation kills the subprocess.
- **Error string shape is preserved byte-for-byte**: \`git %v: %w: %s\` — this matters because \`apply.go:isProtectedBranchLeaseReject\` substring-matches against it.

Migrate all call sites in [internal/gitgraph/gitgraph.go](internal/gitgraph/gitgraph.go), [internal/propagate/plan.go](internal/propagate/plan.go), and [internal/propagate/apply.go](internal/propagate/apply.go). Delete both old helpers.

Prerequisite for [#TBD-rollback] and [#TBD-tag-validate].

## Test plan
- [x] \`go test ./internal/gitx/ ./internal/gitgraph/ ./internal/propagate/ -count=1\` passes
- [x] \`go vet ./...\` clean
- [x] \`grep -R \"shellGit\\|func git(\" internal/\` returns nothing outside \`internal/gitx/\`