### PR TITLE
fix(release): surface rollback errors during Apply

### DIFF
--- a/internal/propagate/apply.go
+++ b/internal/propagate/apply.go
@@ -3,7 +3,9 @@ package propagate
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -73,18 +75,30 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 
 	// Track tags we create locally so we can roll them back.
 	var createdTags []string
-	rollback := func() {
+	rollback := func() error {
+		var errs []error
 		for _, t := range createdTags {
-			_, _ = gitx.Run(context.Background(), ws.Root, "tag", "-d", t)
+			if _, err := gitx.Run(context.Background(), ws.Root, "tag", "-d", t); err != nil {
+				log.Printf("rollback: delete tag %s: %v", t, err)
+				errs = append(errs, fmt.Errorf("delete tag %s: %w", t, err))
+			}
 		}
-		// reset --hard to oldHead: discards release commit and restores working tree.
-		_, _ = gitx.Run(context.Background(), ws.Root, "reset", "--hard", oldHead)
+		if _, err := gitx.Run(context.Background(), ws.Root, "reset", "--hard", oldHead); err != nil {
+			log.Printf("rollback: reset --hard %s: %v", oldHead, err)
+			errs = append(errs, fmt.Errorf("reset --hard %s: %w", oldHead, err))
+		}
+		return errors.Join(errs...)
+	}
+	failAndRollback := func(orig error) error {
+		if rerr := rollback(); rerr != nil {
+			return fmt.Errorf("%w; rollback also failed: %v", orig, rerr)
+		}
+		return orig
 	}
 
 	// 1. Rewrite go.mod + go.sum in topo order.
 	if err := rewriteGoMods(ws, plan); err != nil {
-		rollback()
-		return nil, fmt.Errorf("rewrite go.mods: %w", err)
+		return nil, failAndRollback(fmt.Errorf("rewrite go.mods: %w", err))
 	}
 
 	// 2. Create the release commit (only if rewrites actually changed
@@ -92,18 +106,15 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 	// consumers produce zero go.mod rewrites, so there's nothing to
 	// commit — we tag the existing HEAD instead.
 	if _, err := gitx.Run(context.Background(), ws.Root, "add", "-A"); err != nil {
-		rollback()
-		return nil, err
+		return nil, failAndRollback(err)
 	}
 	hasStaged, err := hasStagedChanges(ws.Root)
 	if err != nil {
-		rollback()
-		return nil, err
+		return nil, failAndRollback(err)
 	}
 	if hasStaged {
 		if _, err := gitx.Run(context.Background(), ws.Root, "commit", "-m", plan.CommitMsg); err != nil {
-			rollback()
-			return nil, fmt.Errorf("create release commit: %w", err)
+			return nil, failAndRollback(fmt.Errorf("create release commit: %w", err))
 		}
 	}
 
@@ -111,22 +122,19 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 	// rewrite module paths (including any /vN majors) are visible.
 	verifyWS, err := workspace.Load(ws.Root)
 	if err != nil {
-		rollback()
-		return nil, fmt.Errorf("reload workspace for verify: %w", err)
+		return nil, failAndRollback(fmt.Errorf("reload workspace for verify: %w", err))
 	}
 	paths := make([]string, 0, len(plan.Entries))
 	for _, e := range plan.Entries {
 		paths = append(paths, targetPath(e))
 	}
 	if err := Verify(ctx, verifyWS, paths); err != nil {
-		rollback()
-		return nil, fmt.Errorf("verify: %w", err)
+		return nil, failAndRollback(fmt.Errorf("verify: %w", err))
 	}
 
 	releaseSHAOut, err := gitx.Run(context.Background(), ws.Root, "rev-parse", "HEAD")
 	if err != nil {
-		rollback()
-		return nil, err
+		return nil, failAndRollback(err)
 	}
 	releaseSHA := trim(releaseSHAOut)
 
@@ -137,15 +145,13 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 			continue
 		}
 		if _, err := gitx.Run(context.Background(), ws.Root, "tag", e.TagName, releaseSHA); err != nil {
-			rollback()
-			return nil, fmt.Errorf("tag %s: %w", e.TagName, err)
+			return nil, failAndRollback(fmt.Errorf("tag %s: %w", e.TagName, err))
 		}
 		createdTags = append(createdTags, e.TagName)
 	}
 	if !tagAlreadyAt(ws.Root, plan.TrainTag, releaseSHA) {
 		if _, err := gitx.Run(context.Background(), ws.Root, "tag", plan.TrainTag, releaseSHA); err != nil {
-			rollback()
-			return nil, fmt.Errorf("tag %s: %w", plan.TrainTag, err)
+			return nil, failAndRollback(fmt.Errorf("tag %s: %w", plan.TrainTag, err))
 		}
 	}
 	createdTags = append(createdTags, plan.TrainTag)

--- a/internal/propagate/apply_rollback_test.go
+++ b/internal/propagate/apply_rollback_test.go
@@ -1,0 +1,87 @@
+package propagate
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/matt0x6f/monoco/internal/bump"
+	"github.com/matt0x6f/monoco/internal/fixture"
+	"github.com/matt0x6f/monoco/internal/workspace"
+)
+
+// TestApply_rollbackFailureSurfaced forces rollback to fail during Verify
+// (by corrupting go.sum AND making the .git dir read-only so tag-delete
+// and reset --hard both error) and asserts the returned error reports
+// both the original failure and the rollback failure.
+func TestApply_rollbackFailureSurfaced(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based rollback failure is POSIX-only")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses chmod")
+	}
+
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "storage"},
+			{Name: "api", DependsOn: []string{"storage"}},
+		},
+	})
+	run(t, fx.Root, "git", "tag", "modules/storage/v0.1.0")
+	run(t, fx.Root, "git", "tag", "modules/api/v0.1.0")
+
+	// Introduce broken source so Verify fails AFTER the commit + tags are
+	// created — this is the path that exercises the full rollback closure.
+	writeFile(t, filepath.Join(fx.Root, "modules/api/api.go"),
+		"package api\n\nimport \"example.com/mono/storage\"\n\nfunc Broken() string { return storage.DoesNotExist() }\n")
+	run(t, fx.Root, "git", "add", "-A")
+	run(t, fx.Root, "git", "commit", "-m", "api: intentionally broken")
+
+	ws, _ := workspace.Load(fx.Root)
+	plan, err := NewPlanForModules(ws, []string{"example.com/mono/storage"}, Options{
+		Slug:  "rollback",
+		Bumps: map[string]bump.Kind{"example.com/mono/storage": bump.Minor},
+	})
+	if err != nil {
+		t.Fatalf("NewPlanForModules: %v", err)
+	}
+
+	// Make .git read-only so rollback's `tag -d` and `reset --hard` both
+	// error. Restore in cleanup so t.TempDir can clean up.
+	gitDir := filepath.Join(fx.Root, ".git")
+	origMode := mustStatMode(t, gitDir)
+	t.Cleanup(func() { _ = os.Chmod(gitDir, origMode) })
+
+	// Defer chmod until just before Apply so fixture setup commits succeed.
+	if err := os.Chmod(gitDir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	_, err = Apply(ws, plan, ApplyOptions{})
+	if err == nil {
+		t.Fatal("expected Apply to fail")
+	}
+
+	msg := err.Error()
+	// The original failure must surface (any git error from the first
+	// step that tripped once .git went read-only).
+	if !strings.Contains(msg, "Permission denied") {
+		t.Errorf("error missing original cause: %v", err)
+	}
+	// And so must the rollback failure.
+	if !strings.Contains(msg, "rollback also failed") {
+		t.Errorf("error missing rollback cause: %v", err)
+	}
+}
+
+func mustStatMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return fi.Mode().Perm()
+}


### PR DESCRIPTION
**Stacked on [#48](https://github.com/matt0x6F/monoco/pull/48).**

## Summary
Apply's rollback closure discarded errors with \`_, _ = gitx.Run(...)\`. A failed tag-delete or reset could leave the repo in an inconsistent state (orphan tags, uncommitted release files) while the caller only saw the original failure.

- \`rollback()\` now returns \`errors.Join\` of every failed attempt, still best-effort continuing.
- New \`failAndRollback(origErr)\` collapses nine duplicated caller blocks and produces: \`<original>; rollback also failed: <joined>\`.
- Logs each rollback sub-failure via \`log.Printf\`.
- Happy path unchanged.

New regression test in [apply_rollback_test.go](internal/propagate/apply_rollback_test.go): chmod \`.git\` read-only to force rollback failure, asserts both original cause and rollback context appear in the returned error. Skips on Windows / root.

## Test plan
- [x] \`go test ./internal/propagate/ -count=1\`
- [x] \`TestApply_rollbackFailureSurfaced\` passes