### PR TITLE
security(release): validate module and train tag names

### DIFF
--- a/internal/propagate/plan.go
+++ b/internal/propagate/plan.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -224,13 +225,17 @@ func buildPlan(ws *workspace.Workspace, modules []string, directSet map[string]s
 		mod := ws.Modules[modPath]
 		_, isDirect := directSet[modPath]
 		rel := normalizeRelDir(mod.RelDir)
+		tag := rel + "/" + versions[modPath]
+		if err := validateModuleTag(tag); err != nil {
+			return nil, fmt.Errorf("module %s: %w", modPath, err)
+		}
 		entries = append(entries, Entry{
 			ModulePath:   modPath,
 			RelDir:       rel,
 			OldVersion:   oldVersions[modPath],
 			NewVersion:   versions[modPath],
 			Kind:         bumps[modPath],
-			TagName:      rel + "/" + versions[modPath],
+			TagName:      tag,
 			DirectChange: isDirect,
 			MajorBump:    majorBumps[modPath],
 		})
@@ -249,6 +254,9 @@ func buildPlan(ws *workspace.Workspace, modules []string, directSet map[string]s
 		slug = "release"
 	}
 	train := fmt.Sprintf("train/%s-%s", now.Format("2006-01-02"), slug)
+	if err := validateTrainTag(train); err != nil {
+		return nil, err
+	}
 
 	return &Plan{
 		Root:      ws.Root,
@@ -400,6 +408,36 @@ func sanitizeSlug(s string) string {
 		}
 	}
 	return strings.Trim(b.String(), "-")
+}
+
+// moduleTagRE matches monoco's per-module tag format: a relative module
+// path (Go-identifier-friendly, slash-separated) joined to a strict
+// semver via "/vX.Y.Z" with optional pre-release metadata. It
+// intentionally rejects "+build" metadata (monoco never emits it),
+// traversal sequences, whitespace, and control runes.
+var moduleTagRE = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*/v\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?$`)
+
+// trainTagRE matches train/<yyyy-mm-dd>-<slug>.
+var trainTagRE = regexp.MustCompile(`^train/\d{4}-\d{2}-\d{2}-[a-z0-9._-]+$`)
+
+func validateModuleTag(name string) error {
+	if name == "" {
+		return fmt.Errorf("module tag is empty")
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("module tag %q contains traversal sequence", name)
+	}
+	if !moduleTagRE.MatchString(name) {
+		return fmt.Errorf("module tag %q is not <modulepath>/vX.Y.Z[-pre]", name)
+	}
+	return nil
+}
+
+func validateTrainTag(name string) error {
+	if !trainTagRE.MatchString(name) {
+		return fmt.Errorf("train tag %q is not train/YYYY-MM-DD-<slug>", name)
+	}
+	return nil
 }
 
 func normalizeRelDir(p string) string {

--- a/internal/propagate/tagvalidate_test.go
+++ b/internal/propagate/tagvalidate_test.go
@@ -1,0 +1,52 @@
+package propagate
+
+import "testing"
+
+func TestValidateModuleTag(t *testing.T) {
+	cases := []struct {
+		in    string
+		valid bool
+	}{
+		{"modules/storage/v0.1.0", true},
+		{"modules/api/v1.2.3-rc.1", true},
+		{"v2/modules/api/v2.0.0", true},
+		{"", false},
+		{"../evil/v0.1.0", false},
+		{"modules/..//v0.1.0", false},
+		{"modules/storage/v0.1", false},
+		{"modules/storage/0.1.0", false},
+		{"modules/storage/v0.1.0+build", false},
+		{"modules/store age/v0.1.0", false},
+		{"modules/store\tage/v0.1.0", false},
+		{"modules/store\x00/v0.1.0", false},
+		{"/modules/storage/v0.1.0", false},
+		{"-modules/storage/v0.1.0", false},
+	}
+	for _, tc := range cases {
+		err := validateModuleTag(tc.in)
+		if (err == nil) != tc.valid {
+			t.Errorf("validateModuleTag(%q) err=%v, want valid=%v", tc.in, err, tc.valid)
+		}
+	}
+}
+
+func TestValidateTrainTag(t *testing.T) {
+	cases := []struct {
+		in    string
+		valid bool
+	}{
+		{"train/2026-04-21-release", true},
+		{"train/2026-04-21-feat-foo.bar_baz", true},
+		{"release/2026-04-21-feat", false},
+		{"train/20260421-release", false},
+		{"train/2026-04-21-", false},
+		{"train/2026-04-21-HASUPPER", false},
+		{"train/2026-04-21-with space", false},
+	}
+	for _, tc := range cases {
+		err := validateTrainTag(tc.in)
+		if (err == nil) != tc.valid {
+			t.Errorf("validateTrainTag(%q) err=%v, want valid=%v", tc.in, err, tc.valid)
+		}
+	}
+}


### PR DESCRIPTION
**Stacked on [#48](https://github.com/matt0x6F/monoco/pull/48).**

## Summary
Tag names were constructed without a character-class guard:
- \`TagName = rel + \"/\" + versions[modPath]\`
- \`train = fmt.Sprintf(\"train/%s-%s\", date, slug)\`

\`gitx.Run\` uses array args so there's no command-injection path, but malformed names could still reach \`refs/tags/\`, break \`go get\` consumers, or carry traversal / control runes.

Two regex validators in [internal/propagate/plan.go](internal/propagate/plan.go):
- \`moduleTagRE\`: \`^[a-zA-Z0-9][a-zA-Z0-9._/-]*/vX.Y.Z[-pre]$\`
- \`trainTagRE\`: \`^train/YYYY-MM-DD-\<lowercase-slug\>$\`

Called at tag construction in \`buildPlan\`. Table-driven tests in [tagvalidate_test.go](internal/propagate/tagvalidate_test.go) cover traversal (\`../evil/...\`), whitespace, control runes, and the intentional rejection of semver \`+build\` metadata (monoco never emits it).

## Test plan
- [x] \`go test ./internal/propagate/ -run TestValidate -count=1\` passes
- [x] Existing propagate suite unaffected