### PR TITLE
fix(propagate): allow mixed-case train-tag slugs

### DIFF
--- a/internal/propagate/plan.go
+++ b/internal/propagate/plan.go
@@ -418,7 +418,7 @@ func sanitizeSlug(s string) string {
 var moduleTagRE = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*/v\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?$`)
 
 // trainTagRE matches train/<yyyy-mm-dd>-<slug>.
-var trainTagRE = regexp.MustCompile(`^train/\d{4}-\d{2}-\d{2}-[a-z0-9._-]+$`)
+var trainTagRE = regexp.MustCompile(`^train/\d{4}-\d{2}-\d{2}-[A-Za-z0-9._-]+$`)
 
 func validateModuleTag(name string) error {
 	if name == "" {

--- a/internal/propagate/tagvalidate_test.go
+++ b/internal/propagate/tagvalidate_test.go
@@ -40,7 +40,8 @@ func TestValidateTrainTag(t *testing.T) {
 		{"release/2026-04-21-feat", false},
 		{"train/20260421-release", false},
 		{"train/2026-04-21-", false},
-		{"train/2026-04-21-HASUPPER", false},
+		{"train/2026-04-21-HASUPPER", true},
+		{"train/2026-04-21-20260421T155118-1a9cf4", true},
 		{"train/2026-04-21-with space", false},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## What

Loosens the train-tag slug character class from `[a-z0-9._-]` to `[A-Za-z0-9._-]`.

## Why

Every `--slug`-passing integration test was failing in CI:

> `monoco: train tag \"train/2026-04-21-20260421T155118-1a9cf4\" is not train/YYYY-MM-DD-<slug>`

The regex was introduced in 2886b6b as a security hardening pass, but:

- Branch-derived slugs go through `sanitizeSlug` (which lowercases), while CLI `--slug` values flow through raw — asymmetric normalization meant legitimate callers were rejected.
- Integration runIDs embed an uppercase `T` from Go's `20060102T150405` timestamp format.

The lowercase-only restriction wasn't earning its keep:
- `gitx.Run` uses array args — injection isn't on the table.
- Git itself rejects control chars and whitespace in ref names.
- Train tags aren't consumed by `go get` (only `<modulepath>/vX.Y.Z` tags are, and those have their own stricter regex).
- The date-prefix shape check — which the parser elsewhere depends on — is unchanged.

## Reviewer notes

- `HASUPPER` flipped from invalid → valid in the validator test, and I pinned the integration-style mixed-case runID so re-tightening the regex breaks the unit test before CI.
- `/` is still rejected (prevents nested refs).
- Propagate suite passes locally.