### PR TITLE
ci: switch to self-hosted ARC runners (monoco-runners)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   unit:
-    runs-on: ubuntu-latest
+    runs-on: monoco-runners
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/integration-sweep.yml
+++ b/.github/workflows/integration-sweep.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   sweep:
-    runs-on: ubuntu-latest
+    runs-on: monoco-runners
     timeout-minutes: 10
     steps:
       - name: Sweep old test refs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   integration:
-    runs-on: ubuntu-latest
+    runs-on: monoco-runners
     # Belt-and-suspenders guard: secret won't be populated on fork PRs.
     # Since this workflow only runs on push-to-main + workflow_dispatch,
     # the secret is always available on approved runs, but the check


### PR DESCRIPTION
## Summary
Switches all workflows from GitHub-hosted `ubuntu-latest` to the self-hosted runner scale set `monoco-runners`, served by Actions Runner Controller on the home k3s cluster.

## Why
Moving CI off GitHub-hosted runners.

## Test plan
- [ ] Merge and confirm a job from any workflow picks up a runner from the `monoco-runners` scale set.
- [ ] Verify on cluster: `kubectl -n arc-runners get pods` shows a new `monoco-runners-…-runner-…` pod while the job is running.