### PR TITLE
fix(propagate): hash modules post-rewrite in topo order; refuse require cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`go.sum` entries for cascaded modules hashed pre-rewrite content.** `release` computed every module's `h1:` hashes up front, before rewriting `go.mod`/`go.sum` — but those files are part of the module zip, so for any mid-chain module (one with both a dependency and a consumer in the plan) the hash pinned downstream described content that never got tagged. Consumers' next module-mode build or `go mod tidy` failed Go's checksum verification with a SECURITY ERROR. Modules are now hashed in plan (topo) order, each after its own rewrites are final.
+
 ### Added
 
 - **Optional `monoco.yaml` manifest** at the repo root for per-module opt-outs and task command overrides. An absent manifest preserves current defaults. ([#1](https://github.com/matt0x6f/monoco/issues/1))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- **Require cycles are now refused with a clear error instead of silently dropping modules.** Two modules that require each other cannot ship in one release — their `go.sum` hashes would be mutually recursive (a property of Go's checksum model, not monoco). Previously the planner's topo sort silently omitted cycle members from the plan; now `release` names the cycle and points at the `--bump <module>=skip` remedy. See the new "Require cycles are refused" section in [docs/release-model.md](docs/release-model.md).
 - **`go.sum` entries for cascaded modules hashed pre-rewrite content.** `release` computed every module's `h1:` hashes up front, before rewriting `go.mod`/`go.sum` — but those files are part of the module zip, so for any mid-chain module (one with both a dependency and a consumer in the plan) the hash pinned downstream described content that never got tagged. Consumers' next module-mode build or `go mod tidy` failed Go's checksum verification with a SECURITY ERROR. Modules are now hashed in plan (topo) order, each after its own rewrites are final.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Requires Go 1.22+.
 
 ```bash
 # One-time: generate go.work from your existing go.mod files.
+# Commit what it writes — and go.work.sum once workspace commands
+# create it — because `release` requires a clean working tree.
 monoco init
 
 # During development, pin in-flight modules with a workspace-local replace
@@ -50,6 +52,12 @@ monoco build --since origin/main
 monoco generate --since origin/main
 ```
 
+The fanout commands exist because `go build ./...` at the workspace root
+doesn't cross module boundaries — Go's package patterns stop at the
+module containing the current directory
+([golang/go#50745](https://github.com/golang/go/issues/50745)). monoco
+runs the standard command in each affected module instead.
+
 ## Using monoco in CI
 
 monoco is a CLI, so CI calls it like any other Go binary. A reference
@@ -79,9 +87,9 @@ Gotchas worth flagging when you copy it:
   same repo. If branch protection blocks bot pushes, swap in a PAT or a
   GitHub App token with `contents: write` on `actions/checkout` and
   update the `apply` job accordingly.
-- Major-version bumps across the `/vN` boundary are refused today
-  (see [Conventions](#conventions)); the workflow won't rescue you from
-  that — `monoco release --dry-run` will just fail the `plan` job.
+- Major-version bumps across the `/vN` boundary require an explicit
+  `--allow-major <module>` (or `allow_major` in `monoco.yaml`); without
+  it, `monoco release --dry-run` will just fail the `plan` job.
 
 ## Conventions
 
@@ -92,7 +100,9 @@ Gotchas worth flagging when you copy it:
 - **Bump kinds default to `patch`** for every module in the plan. Override per-module with `--bump <module>=<minor|major|skip>`. No commit-message inference, no prompting, no Conventional Commits dependency.
 - A **direct-affected** module is one whose source is under active local development, identified by the presence of a workspace-local `replace` directive pointing at it from any sibling module's `go.mod`.
 - A **cascaded** module is a consumer of a direct-affected module. It gets the same default-patch treatment as directs; override with `--bump` if needed.
-- v2+ major-version boundary crossings are refused (they require `/vN` path rewrites across `module` + `require` + imports; planned for a future release).
+- Major-version boundary crossings need an explicit opt-in: `--allow-major <module>` (or `allow_major` in `monoco.yaml`). monoco then rewrites the `/vN` suffix across the bumper's `module` line and every consumer's `require` + imports. At most one module per release may cross.
+- On a v0 module, `--bump <module>=major` coerces to a minor bump (`v0.2.0 → v0.3.0`) — v0 is explicitly unstable in Go's semver convention, so there's no boundary to cross. Bump to `v1` by tagging `<module>/v1.0.0` by hand once, then let monoco take over.
+- **Modules that require each other can't ship in the same release.** Each side's `go.sum` would need the `h1:` hash of the other's not-yet-final content — the hashes are mutually recursive, so no tool can produce them (this is a property of Go's checksum model, not a monoco limitation). `release` refuses the plan and names the cycle; ship one side at a time with `--bump <module>=skip`, keeping its require pinned to the other's previously tagged version.
 
 ## How it works
 
@@ -185,7 +195,6 @@ Excluded modules never show up in `monoco affected`, `monoco release`, or task f
 
 ## Not in scope (yet)
 
-- v2+ major-version path rewriting.
 - Forward-propagation of orphan tags cut by hand.
 - PR creation (intentionally forge-agnostic — wrap with `gh` / `glab` / whatever).
 - `monoco doctor`.

--- a/docs/release-model.md
+++ b/docs/release-model.md
@@ -20,6 +20,8 @@ monoco collapses this into one step:
 
 External consumers see honest per-module semver tags, resolvable by `go get` with no monoco knowledge required.
 
+**Why one commit can carry all the tags.** Go resolves a version tag → commit, never commit → tag. A single commit can therefore contain B's `go.mod` requiring `C@v0.2.0` while the tag `c/v0.2.0` points at that very commit — there is no ordering constraint to violate. The chicken-and-egg in the sequential flow comes from each tag needing to exist *on the remote* before the next module can build against it; landing every tag in one atomic push removes that gap entirely.
+
 ## The direct-affected set
 
 A **direct-affected** module is one whose source is under active local development. monoco identifies it by a workspace-local `replace` directive pointing at it from any sibling module's `go.mod`:
@@ -78,6 +80,12 @@ monoco computes the hashes in-process via `golang.org/x/mod/zip` + `golang.org/x
 Ordering matters: a cascaded module's *own* `go.mod` and `go.sum` are rewritten by the release, and those files are part of its module zip. Each module is therefore hashed only after its final content is known, walking the plan in topo order (dependencies before consumers), so the `h1:` lines a consumer pins describe the bytes the tag will actually contain. Hashing pre-rewrite state would poison the entry for every mid-chain module — the next module-mode build or `go mod tidy` would fail Go's checksum verification.
 
 Validated by POC-4 — see [poc-findings.md](poc-findings.md).
+
+## Require cycles are refused
+
+The one shape the atomic model cannot ship: two modules that require each other — directly or transitively — both in the same plan. A module's zip includes its own `go.sum`, so A's new zip would have to embed B's new `h1:` hash while B's embeds A's. The hashes are mutually recursive; no fixed point exists, for monoco or any other tool. This is a property of Go's checksum model, not a monoco choice: module-level cycles are legal in Go, and projects that have them always pin the *previous* version of the other side across the back-edge.
+
+`release` detects the cycle while topo-ordering the plan and refuses, naming the members. The remedy is the same one the Go ecosystem uses: release one side at a time (`--bump <module>=skip` the others), keeping its require pinned to the previously tagged version of the other side.
 
 ## Atomic publish
 

--- a/docs/release-model.md
+++ b/docs/release-model.md
@@ -87,6 +87,8 @@ The one shape the atomic model cannot ship: two modules that require each other 
 
 `release` detects the cycle while topo-ordering the plan and refuses, naming the members. The remedy is the same one the Go ecosystem uses: release one side at a time (`--bump <module>=skip` the others), keeping its require pinned to the previously tagged version of the other side.
 
+The refusal is not the end state: a release can be generalized to an ordered chain of commits inside one atomic push, which breaks the hash recursion by commit ordering. See [staged-releases.md](staged-releases.md) for the design.
+
 ## Atomic publish
 
 ```

--- a/docs/release-model.md
+++ b/docs/release-model.md
@@ -75,6 +75,8 @@ Downstreams' `go.sum` files need canonical `h1:` hashes for the freshly-tagged d
 
 monoco computes the hashes in-process via `golang.org/x/mod/zip` + `golang.org/x/mod/sumdb/dirhash`. No network, no proxy, no tag-then-download race. The hashes are bit-identical to what the Go module proxy would produce after the push, so consumers' `go.sum` verification passes cleanly.
 
+Ordering matters: a cascaded module's *own* `go.mod` and `go.sum` are rewritten by the release, and those files are part of its module zip. Each module is therefore hashed only after its final content is known, walking the plan in topo order (dependencies before consumers), so the `h1:` lines a consumer pins describe the bytes the tag will actually contain. Hashing pre-rewrite state would poison the entry for every mid-chain module — the next module-mode build or `go mod tidy` would fail Go's checksum verification.
+
 Validated by POC-4 — see [poc-findings.md](poc-findings.md).
 
 ## Atomic publish

--- a/docs/staged-releases.md
+++ b/docs/staged-releases.md
@@ -1,0 +1,151 @@
+# Staged releases (design proposal)
+
+**Status: proposed, not implemented.** This documents the design for releasing
+modules that participate in require cycles — the one shape the current atomic
+model refuses (see [release-model.md](release-model.md#require-cycles-are-refused)).
+It exists so the refusal's eventual replacement is designed next to the
+constraint that motivates it.
+
+## The constraint, restated
+
+Two modules that require each other cannot be tagged at the same commit. A
+module's zip embeds its own `go.sum`, so A's new zip would have to contain
+B's new `h1:` hash while B's contains A's. The hashes are mutually recursive;
+no fixed point exists. This is a property of Go's checksum model, and no
+release tool can compute its way around it.
+
+Today `release` detects the cycle while topo-ordering the plan and refuses,
+naming the members and pointing at `--bump <module>=skip`. That makes the
+user the release engineer: ship one side pinned to the other's previous tag,
+then ship the other side. Correct, honest — and mechanical enough to automate.
+
+## The insight: the impossibility is per-commit, not per-push
+
+Nothing in the model requires a release to be one commit. Generalize from
+
+> one commit, N tags, one atomic push
+
+to
+
+> an ordered **chain** of commits, tags distributed across them, still **one
+> atomic push**.
+
+For a two-module cycle `A ⇄ B`:
+
+```
+commit 1  finalize B: its go.mod keeps requiring A@v1.2.3 (the previous tag)
+          tag modules/b/v0.4.0 → commit 1
+
+commit 2  rewrite A: require B@v0.4.0 — hashable now, B's content is final
+          tag modules/a/v1.3.0 → commit 2
+          tag train/<date>-<slug> → commit 2 (the tip)
+
+git push --atomic origin <branch> <all four refs>
+```
+
+The hash recursion is broken by commit ordering instead of being unsolvable
+within one commit. Atomicity survives at the boundary where it matters — the
+publish: consumers see either the whole release or none of it. And the
+resulting history is exactly what a careful release engineer produces by hand
+(this is how cyclic module pairs in the wild, e.g. the grpc-go ecosystem,
+already version their back-edges) — just derived and executed mechanically.
+
+A release therefore becomes a list of **stages**. An acyclic plan is one
+stage: byte-for-byte today's behavior. The new vocabulary only appears when a
+cycle exists.
+
+## Stage planning
+
+1. Build the condensation of the in-plan require graph (strongly-connected
+   components, contracted). The condensation is a DAG; its topo order is the
+   stage order. Modules outside any cycle ride whichever stage their
+   dependencies complete in.
+2. Within an SCC, pick the **cut**: which member releases first, keeping its
+   require on the other member(s) pinned to their previous tags.
+3. Emit one commit per stage, tags on each stage's commit, train tag on the
+   tip, one atomic push of the whole chain.
+
+Rollback semantics are unchanged: every commit and tag is local until the
+single push; any pre-push failure restores the pre-run state.
+
+## Cut selection is derived, not declared
+
+The side that releases first ships requiring the *previous* tag of its cycle
+partner — so external consumers will compile it against old content, even
+though the user's workspace compiled it against new content. That makes cut
+selection a **verification question**, which keeps it out of `monoco.yaml`:
+
+- Try each cut direction. A direction is viable iff the first side's new
+  content builds in module mode against its partner's *pinned tag content*
+  (see below).
+- Exactly one viable direction: use it.
+- Both viable: prefer the direction that stages the direct-affected module
+  last (its consumers see the freshest content), break ties
+  deterministically; a `--cut <module>` flag can override.
+- **Neither viable:** both new sides need each other's new API
+  simultaneously. That is not a tooling failure and must not be papered
+  over — tags that don't compile for consumers are worse than no tags. The
+  error says exactly that:
+
+  > modules A and B are release-coupled: each side's new code requires the
+  > other's new API, so no staged order compiles for external consumers.
+  > This cycle is one module pretending to be two — merge them, or break the
+  > require cycle in code.
+
+The three exits — auto-staged release, explicit cut, architectural verdict —
+replace today's single refusal.
+
+## Pinned-content verification
+
+The new machinery staged releases require. Today's `Verify` redirects every
+in-plan require to the dependency's **workspace directory** via `replace`,
+which is correct only when the dependency ships in the same commit. A staged
+release pins the previous tag, so verification must materialize the
+dependency *at that tag* (e.g. `git worktree`/`git archive` into a temp dir)
+and point the `replace` there.
+
+This fixes an existing blind spot too: with `--bump <module>=skip`, the
+skipped module's consumers are verified against its workspace dir today, not
+against the old tag their rewritten `go.mod` actually pins. Same machinery,
+same fix.
+
+## User experience
+
+One command, one confirmation. The plan grows a stage column only when
+staging is needed:
+
+```
+Plan:
+  Train: train/2026-06-10-auth-refactor
+
+  STAGE  MODULE                    OLD     NEW     KIND   DIRECT
+  1      modules/users             v0.3.2  v0.3.3  patch  cascade   (pins auth v1.2.3 — previous)
+  2      modules/auth              v1.2.3  v1.3.0  minor  direct    (pins users v0.3.3)
+  2      modules/gateway           v0.9.0  v0.9.1  patch  cascade
+```
+
+## Scope check
+
+Against the scoping principles in [AGENTS.md](../AGENTS.md):
+
+- **Derive, don't declare** — stages and cuts come from the require graph and
+  verification, not configuration. `--cut` is an override, never a requirement.
+- **Tags are the public API** — unchanged. Per-module semver tags, each
+  pointing at a commit where that module's content is final and consistent.
+- **Leave-able** — the history is indistinguishable from a hand-rolled
+  staggered release.
+- **One concept at a time** — "stage" is the single addition, visible only
+  when a cycle forces it.
+
+## Open questions
+
+- Verification cost: each candidate cut direction is a module-mode build of
+  the first stage; a two-member cycle costs at most two extra builds. Fine.
+  Pathological many-SCC plans could multiply this — probably acceptable to
+  verify only the chosen order and fail late.
+- Interaction with major bumps: a `/vN` crossing inside a cycle changes the
+  partner's import paths; stage 1 cannot pin "previous tag" across a path
+  rename. Likely refuse major bumps within an SCC initially.
+- Pushes with chained commits assume the base branch hasn't advanced
+  mid-apply; the existing `--force-with-lease` + base-SHA preflight already
+  covers this.

--- a/internal/propagate/apply.go
+++ b/internal/propagate/apply.go
@@ -182,7 +182,8 @@ type RewrittenMod struct {
 	GoModPath    string                      // absolute path to go.mod
 	Old          []byte                      // current bytes on disk
 	New          []byte                      // proposed bytes after applying the plan
-	SumAdds      []string                    // lines to append to this module's go.sum (may be empty)
+	SumAdds      []string                    // lines merged into this module's go.sum (may be empty)
+	SumNew       []byte                      // full proposed go.sum contents (valid iff SumAdds non-empty)
 	GoSumPath    string                      // absolute path to go.sum (valid iff SumAdds non-empty)
 	GoFileEdits  []importrewrite.FileChange  // .go source rewrites for major-version path migrations
 	SkippedFiles []importrewrite.SkippedFile // .go files the rewriter skipped (build-tag gated)
@@ -224,19 +225,14 @@ func ComputeRewrites(ws *workspace.Workspace, plan *Plan) (map[string]RewrittenM
 		}
 	}
 
-	// Precompute canonical h1: hashes for each released module, keyed
-	// by the module's post-plan path (so entries generated from a
-	// /vN-rewritten go.mod line up).
+	// Canonical h1: hashes for each released module, keyed by the
+	// module's post-plan path (so entries generated from a /vN-rewritten
+	// go.mod line up). Each module is hashed only after its own rewrites
+	// are known — plan.Entries is topo-ordered (dependencies before
+	// consumers), so a consumer's go.sum entry always describes the
+	// content its dependency will actually have at the release commit.
+	// Hashing pre-rewrite state would corrupt every mid-chain entry.
 	hashes := map[string]ModuleHashes{}
-	for _, e := range plan.Entries {
-		dir := ws.Modules[e.ModulePath].Dir
-		target := targetPath(e)
-		h, err := ComputeModuleHashes(dir, target, e.NewVersion)
-		if err != nil {
-			return nil, fmt.Errorf("hash %s@%s: %w", target, e.NewVersion, err)
-		}
-		hashes[target] = h
-	}
 
 	out := map[string]RewrittenMod{}
 	for _, e := range plan.Entries {
@@ -322,10 +318,14 @@ func ComputeRewrites(ws *workspace.Workspace, plan *Plan) (map[string]RewrittenM
 
 		// Always compute sum additions for deps this module references
 		// (caught via Require above). Cascaded modules may have no
-		// in-plan requires — skip them.
+		// in-plan requires — skip them. Deps precede this module in
+		// plan order, so their post-rewrite hashes are already known.
 		var sumAdds []string
 		for dep := range referencedDeps {
-			h := hashes[dep]
+			h, hashed := hashes[dep]
+			if !hashed {
+				return nil, fmt.Errorf("internal: %s required by %s before being hashed; require cycle among released modules?", dep, e.ModulePath)
+			}
 			depV := targetVersion[dep]
 			sumAdds = append(sumAdds,
 				fmt.Sprintf("%s %s %s", dep, depV, h.H1),
@@ -349,14 +349,54 @@ func ComputeRewrites(ws *workspace.Workspace, plan *Plan) (map[string]RewrittenM
 			skipped = rep.SkippedFiles
 		}
 
-		if !modChanged && len(sumAdds) == 0 && len(goEdits) == 0 {
-			continue
+		goSumPath := filepath.Join(modDir, "go.sum")
+		var sumNew []byte
+		if len(sumAdds) > 0 {
+			existing, rerr := os.ReadFile(goSumPath)
+			if rerr != nil && !os.IsNotExist(rerr) {
+				return nil, fmt.Errorf("read %s: %w", goSumPath, rerr)
+			}
+			sumNew = mergeGoSumBytes(existing, sumAdds)
 		}
 
-		mf.Cleanup()
-		formatted, err := mf.Format()
+		noWrite := !modChanged && len(sumAdds) == 0 && len(goEdits) == 0
+
+		// This module's final go.mod bytes: formatted when a rewrite will
+		// be written, the on-disk bytes when nothing changes (Format may
+		// normalize cosmetically, and an unwritten file keeps its bytes).
+		goModFinal := b
+		var formatted []byte
+		if !noWrite {
+			mf.Cleanup()
+			formatted, err = mf.Format()
+			if err != nil {
+				return nil, fmt.Errorf("format %s: %w", goModPath, err)
+			}
+			goModFinal = formatted
+		}
+
+		// Hash this module as it will exist at the release commit, so
+		// consumers later in plan order pin the tagged content.
+		overlay := map[string][]byte{"go.mod": goModFinal}
+		if len(sumNew) > 0 {
+			overlay["go.sum"] = sumNew
+		}
+		for _, fc := range goEdits {
+			relPath, rerr := filepath.Rel(modDir, fc.Path)
+			if rerr != nil {
+				return nil, fmt.Errorf("relativize %s: %w", fc.Path, rerr)
+			}
+			overlay[filepath.ToSlash(relPath)] = fc.New
+		}
+		target := targetPath(e)
+		h, err := hashModuleWithOverlay(modDir, target, e.NewVersion, overlay)
 		if err != nil {
-			return nil, fmt.Errorf("format %s: %w", goModPath, err)
+			return nil, fmt.Errorf("hash %s@%s: %w", target, e.NewVersion, err)
+		}
+		hashes[target] = h
+
+		if noWrite {
+			continue
 		}
 
 		r := RewrittenMod{
@@ -364,11 +404,12 @@ func ComputeRewrites(ws *workspace.Workspace, plan *Plan) (map[string]RewrittenM
 			Old:          b,
 			New:          formatted,
 			SumAdds:      sumAdds,
+			SumNew:       sumNew,
 			GoFileEdits:  goEdits,
 			SkippedFiles: skipped,
 		}
 		if len(sumAdds) > 0 {
-			r.GoSumPath = filepath.Join(ws.Modules[e.ModulePath].Dir, "go.sum")
+			r.GoSumPath = goSumPath
 		}
 		out[e.ModulePath] = r
 	}
@@ -393,29 +434,27 @@ func rewriteGoMods(ws *workspace.Workspace, plan *Plan) error {
 				return fmt.Errorf("write %s: %w", fc.Path, err)
 			}
 		}
-		if len(r.SumAdds) == 0 {
+		if len(r.SumNew) == 0 {
 			continue
 		}
-		if err := mergeGoSum(r.GoSumPath, r.SumAdds); err != nil {
-			return fmt.Errorf("merge %s: %w", r.GoSumPath, err)
+		// Write the exact bytes that were hashed in ComputeRewrites so
+		// the release commit matches the h1: entries pinned downstream.
+		if err := os.WriteFile(r.GoSumPath, r.SumNew, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", r.GoSumPath, err)
 		}
 	}
 	return nil
 }
 
-// mergeGoSum appends lines to a go.sum, deduplicating with any existing
-// content, and keeps the file sorted.
-func mergeGoSum(goSumPath string, adds []string) error {
+// mergeGoSumBytes merges adds into existing go.sum content,
+// deduplicating, and keeps the result sorted.
+func mergeGoSumBytes(existingContent []byte, adds []string) []byte {
 	var existing [][]byte
-	if b, err := os.ReadFile(goSumPath); err == nil {
-		for _, line := range bytes.Split(b, []byte("\n")) {
-			if len(line) == 0 {
-				continue
-			}
-			existing = append(existing, line)
+	for _, line := range bytes.Split(existingContent, []byte("\n")) {
+		if len(line) == 0 {
+			continue
 		}
-	} else if !os.IsNotExist(err) {
-		return err
+		existing = append(existing, line)
 	}
 	seen := map[string]struct{}{}
 	for _, l := range existing {
@@ -436,7 +475,7 @@ func mergeGoSum(goSumPath string, adds []string) error {
 		buf.Write(l)
 		buf.WriteByte('\n')
 	}
-	return os.WriteFile(goSumPath, buf.Bytes(), 0o644)
+	return buf.Bytes()
 }
 
 func requireCleanWorkingTree(root string) error {

--- a/internal/propagate/gosum.go
+++ b/internal/propagate/gosum.go
@@ -3,6 +3,7 @@ package propagate
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -47,4 +48,68 @@ func ComputeModuleHashes(modDir, modPath, version string) (ModuleHashes, error) 
 		return ModuleHashes{}, fmt.Errorf("hash go.mod: %w", err)
 	}
 	return ModuleHashes{H1: h1, H1Mod: h1mod}, nil
+}
+
+// hashModuleWithOverlay computes the canonical h1: hashes for the module
+// rooted at modDir as it will exist at the release commit: overlay maps
+// module-relative file paths (slash-separated) to their post-rewrite
+// contents. The module is staged into a temp dir so the working tree is
+// never touched — dry-run and apply share this path.
+func hashModuleWithOverlay(modDir, modPath, version string, overlay map[string][]byte) (ModuleHashes, error) {
+	if len(overlay) == 0 {
+		return ComputeModuleHashes(modDir, modPath, version)
+	}
+	tmp, err := os.MkdirTemp("", "monoco-modstage-*")
+	if err != nil {
+		return ModuleHashes{}, fmt.Errorf("create staging dir: %w", err)
+	}
+	defer os.RemoveAll(tmp)
+	if err := stageDir(modDir, tmp); err != nil {
+		return ModuleHashes{}, fmt.Errorf("stage %s: %w", modDir, err)
+	}
+	for rel, content := range overlay {
+		dst := filepath.Join(tmp, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return ModuleHashes{}, err
+		}
+		if err := os.WriteFile(dst, content, 0o644); err != nil {
+			return ModuleHashes{}, err
+		}
+	}
+	return ComputeModuleHashes(tmp, modPath, version)
+}
+
+// stageDir copies the regular files under src into dst, preserving
+// relative layout. Non-regular files (symlinks, devices) are skipped —
+// modzip.CreateFromDir omits them from module zips anyway, so the staged
+// copy hashes identically. VCS metadata dirs are skipped for the same
+// reason.
+func stageDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if rel == "." {
+				return nil
+			}
+			switch d.Name() {
+			case ".git", ".hg", ".svn", ".bzr":
+				return fs.SkipDir
+			}
+			return os.MkdirAll(filepath.Join(dst, rel), 0o755)
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(dst, rel), b, 0o644)
+	})
 }

--- a/internal/propagate/gosum_order_test.go
+++ b/internal/propagate/gosum_order_test.go
@@ -1,0 +1,98 @@
+package propagate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/matt0x6f/monoco/internal/bump"
+	"github.com/matt0x6f/monoco/internal/fixture"
+	"github.com/matt0x6f/monoco/internal/workspace"
+)
+
+// TestRewriteGoMods_SumEntriesMatchPostRewriteContent pins the ordering
+// property behind every multi-level cascade: the h1: lines written into a
+// consumer's go.sum must hash the dependency's content as it will exist
+// at the release commit — AFTER the dependency's own go.mod/go.sum were
+// rewritten. Hashing pre-rewrite state poisons the entry for every
+// mid-chain module: the next module-mode build or `go mod tidy` fails
+// with Go's checksum-mismatch SECURITY ERROR.
+//
+// Chain: core ← storage ← api. Releasing core rewrites storage's go.mod
+// (require bump + replace strip) and go.sum (new core lines), so the
+// storage@v0.1.1 entry in api/go.sum must match storage's post-rewrite
+// directory, not its pre-rewrite one.
+func TestRewriteGoMods_SumEntriesMatchPostRewriteContent(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "core"},
+			{Name: "storage", DependsOn: []string{"core"}},
+			{Name: "api", DependsOn: []string{"storage"}},
+		},
+	})
+	run(t, fx.Root, "git", "tag", "modules/core/v0.1.0")
+	run(t, fx.Root, "git", "tag", "modules/storage/v0.1.0")
+	run(t, fx.Root, "git", "tag", "modules/api/v0.1.0")
+
+	// In-flight change to core, declared via a workspace-local replace
+	// in storage (so the release also strips it from storage/go.mod).
+	storageGoMod := filepath.Join(fx.Root, "modules/storage/go.mod")
+	orig, err := osReadFile(storageGoMod)
+	if err != nil {
+		t.Fatalf("read storage go.mod: %v", err)
+	}
+	if err := osWriteFile(storageGoMod, orig+"\nreplace example.com/mono/core => ../core\n"); err != nil {
+		t.Fatalf("write storage go.mod: %v", err)
+	}
+	writeFile(t, filepath.Join(fx.Root, "modules/core/core.go"),
+		"package core\n\nfunc CoreHello() string { return \"core\" }\nfunc Feature() string { return \"new\" }\n")
+	run(t, fx.Root, "git", "add", "-A")
+	run(t, fx.Root, "git", "commit", "-m", "core: feature, storage: replace")
+
+	ws, err := workspace.Load(fx.Root)
+	if err != nil {
+		t.Fatalf("workspace.Load: %v", err)
+	}
+	plan, err := NewPlanForModules(ws, []string{"example.com/mono/core"}, Options{
+		Slug:  "test",
+		Bumps: map[string]bump.Kind{"example.com/mono/core": bump.Minor},
+	})
+	if err != nil {
+		t.Fatalf("NewPlanForModules: %v", err)
+	}
+
+	if err := rewriteGoMods(ws, plan); err != nil {
+		t.Fatalf("rewriteGoMods: %v", err)
+	}
+
+	// The canonical truth: hash each dependency's directory as it now
+	// exists on disk — the content the release commit will tag.
+	cases := []struct {
+		depPath, depDir, version, consumerSum string
+	}{
+		{"example.com/mono/core", "modules/core", "v0.2.0", "modules/storage/go.sum"},
+		{"example.com/mono/storage", "modules/storage", "v0.1.1", "modules/api/go.sum"},
+	}
+	for _, c := range cases {
+		want, err := ComputeModuleHashes(filepath.Join(fx.Root, c.depDir), c.depPath, c.version)
+		if err != nil {
+			t.Fatalf("hash post-rewrite %s: %v", c.depPath, err)
+		}
+		sumBytes, err := os.ReadFile(filepath.Join(fx.Root, c.consumerSum))
+		if err != nil {
+			t.Fatalf("read %s: %v", c.consumerSum, err)
+		}
+		sum := string(sumBytes)
+		zipLine := c.depPath + " " + c.version + " " + want.H1
+		modLine := c.depPath + " " + c.version + "/go.mod " + want.H1Mod
+		if !strings.Contains(sum, zipLine) {
+			t.Errorf("%s pins a hash for %s@%s that does not match the post-rewrite content.\nwant line: %s\ngot:\n%s",
+				c.consumerSum, c.depPath, c.version, zipLine, sum)
+		}
+		if !strings.Contains(sum, modLine) {
+			t.Errorf("%s pins a go.mod hash for %s@%s that does not match the post-rewrite go.mod.\nwant line: %s\ngot:\n%s",
+				c.consumerSum, c.depPath, c.version, modLine, sum)
+		}
+	}
+}

--- a/internal/propagate/plan.go
+++ b/internal/propagate/plan.go
@@ -218,7 +218,11 @@ func buildPlan(ws *workspace.Workspace, modules []string, directSet map[string]s
 		}
 		active = append(active, m)
 	}
-	ordered := topoOrder(ws, active)
+	ordered, cycle := topoOrder(ws, active)
+	if len(cycle) > 0 {
+		sort.Strings(cycle)
+		return nil, fmt.Errorf("require cycle among release modules: %s\nan atomic release cannot tag both sides of a require cycle: each module's go.sum would need the h1: hash of the other's not-yet-final content, and those hashes are mutually recursive. Release one side at a time (--bump <module>=skip the others), keeping its require pinned to the previously tagged version", strings.Join(cycle, ", "))
+	}
 
 	entries := make([]Entry, 0, len(ordered))
 	for _, modPath := range ordered {
@@ -309,8 +313,11 @@ func transitiveClosure(ws *workspace.Workspace, seeds []string) []string {
 }
 
 // topoOrder returns module paths in a deterministic topological order:
-// if A requires B (B in workspace), B precedes A.
-func topoOrder(ws *workspace.Workspace, modules []string) []string {
+// if A requires B (B in workspace), B precedes A. Modules trapped in a
+// require cycle never reach in-degree zero; they are returned separately
+// in cycle so the caller can refuse the plan with a useful error instead
+// of silently dropping them.
+func topoOrder(ws *workspace.Workspace, modules []string) (ordered, cycle []string) {
 	inSet := map[string]bool{}
 	for _, m := range modules {
 		inSet[m] = true
@@ -349,7 +356,39 @@ func topoOrder(ws *workspace.Workspace, modules []string) []string {
 			}
 		}
 	}
-	return out
+	if len(out) < len(modules) {
+		// Everything Kahn's couldn't emit is either on a cycle or
+		// downstream of one. Iteratively trimming nodes with no
+		// consumers among the leftovers strips the downstream tail,
+		// so the error names only the modules that require each other.
+		left := map[string]bool{}
+		for _, m := range modules {
+			left[m] = true
+		}
+		for _, m := range out {
+			delete(left, m)
+		}
+		for trimmed := true; trimmed; {
+			trimmed = false
+			for m := range left {
+				hasConsumer := false
+				for _, c := range edges[m] {
+					if left[c] {
+						hasConsumer = true
+						break
+					}
+				}
+				if !hasConsumer {
+					delete(left, m)
+					trimmed = true
+				}
+			}
+		}
+		for m := range left {
+			cycle = append(cycle, m)
+		}
+	}
+	return out, cycle
 }
 
 // CurrentBranch returns the short name of the branch currently checked

--- a/internal/propagate/plan_test.go
+++ b/internal/propagate/plan_test.go
@@ -270,3 +270,55 @@ func headSHA(t *testing.T, root string) string {
 	}
 	return s
 }
+
+func TestNewPlanForModules_requireCycleError(t *testing.T) {
+	fx := fixture.New(t, fixture.Spec{
+		Modules: []fixture.ModuleSpec{
+			{Name: "auth", DependsOn: []string{"users"}},
+			{Name: "users", DependsOn: []string{"auth"}},
+			{Name: "gateway", DependsOn: []string{"auth"}},
+		},
+	})
+	ws, err := workspace.Load(fx.Root)
+	if err != nil {
+		t.Fatalf("workspace.Load: %v", err)
+	}
+	_, err = NewPlanForModules(ws, []string{"example.com/mono/auth"}, Options{
+		Slug:  "test",
+		Bumps: map[string]bump.Kind{"example.com/mono/auth": bump.Minor},
+	})
+	if err == nil {
+		t.Fatal("expected a require-cycle error, got nil")
+	}
+	if !strings.Contains(err.Error(), "require cycle") {
+		t.Errorf("error should mention the require cycle, got: %v", err)
+	}
+	for _, m := range []string{"example.com/mono/auth", "example.com/mono/users"} {
+		if !strings.Contains(err.Error(), m) {
+			t.Errorf("error should name cycle member %s, got: %v", m, err)
+		}
+	}
+	if strings.Contains(err.Error(), "example.com/mono/gateway") {
+		t.Errorf("gateway is downstream of the cycle, not in it; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "skip") {
+		t.Errorf("error should point at the --bump skip remedy, got: %v", err)
+	}
+
+	// Skipping one side breaks the cycle and the plan goes through.
+	plan, err := NewPlanForModules(ws, []string{"example.com/mono/auth"}, Options{
+		Slug: "test",
+		Bumps: map[string]bump.Kind{
+			"example.com/mono/auth":  bump.Minor,
+			"example.com/mono/users": bump.Skip,
+		},
+	})
+	if err != nil {
+		t.Fatalf("plan with cycle broken by skip: %v", err)
+	}
+	for _, e := range plan.Entries {
+		if e.ModulePath == "example.com/mono/users" {
+			t.Errorf("skipped module present in plan: %+v", plan.Entries)
+		}
+	}
+}

--- a/monoco.yaml
+++ b/monoco.yaml
@@ -2,4 +2,7 @@ version: 1
 
 tasks:
   test:
-    command: ["go", "test", "./...", "-count=1", "-race", "-timeout=5m"]
+    # No -race: the monoco-runners ARC image has CGO_ENABLED=0 and no C
+    # toolchain, and -race requires cgo. Restore it if the runner image
+    # grows gcc (and set CGO_ENABLED=1 in ci.yml).
+    command: ["go", "test", "./...", "-count=1", "-timeout=5m"]


### PR DESCRIPTION
## The bug

`ComputeRewrites` computed every plan module's `h1:` hashes **up front, from pre-rewrite disk state**. But a cascaded module's own `go.mod` (require bumps, replace strips) and `go.sum` (new dep lines) are rewritten by the release — and both files are part of its module zip. So for any **mid-chain** module (one with both a dependency and a consumer in the plan), the hash pinned into its consumers' `go.sum` described content that never got tagged.

Found during an end-to-end validation against a production-shaped monorepo (`core ← storage ← api ← web`, external dep on `golang.org/x/text`, prior tags served through a file-based GOPROXY). After `monoco release`:

- `web/go.sum` pinned `api v0.1.1/go.mod h1:Cx7u…` — byte-identical to the **v0.1.0** line, because the old `go.mod` was hashed. The canonical hash of the tagged content is `G6p0…`.
- Only the leaf (`core`, never rewritten) matched; both mid-chain modules (`storage`, `api`) were poisoned.
- The next `go mod tidy` or module-mode build in the repo failed with Go's checksum-mismatch **SECURITY ERROR**, for every developer.

Why nothing caught it: the local fixtures' modules have no external deps or `go.sum` files; `gosum_test.go` validates the hash *function* on a static directory (it's correct — the orchestration order was wrong); and the release `Verify` step uses `-modfile` + replace directives, which bypass sum verification entirely.

## The fix

Hash each module **after** its final content is known, walking `plan.Entries` in its existing topo order (dependencies before consumers):

- Per entry: compute final `go.mod` bytes and `.go` import rewrites, build `go.sum` additions from the already-computed (post-rewrite) dep hashes, merge the final `go.sum` bytes, then hash the module via a temp-dir overlay — so dry-run still never touches the working tree.
- `rewriteGoMods` now writes the exact `go.sum` bytes that were hashed (`SumNew`), instead of re-merging at write time.

This also fixes the same staleness for major-bump releases, where `.go` import rewrites change module content after the old upfront hashing.

## Require cycles: refused with a user-facing error

Topo-order hashing surfaces the one shape an atomic release fundamentally cannot ship: modules that require each other. Each side's zip embeds its own `go.sum`, so each hash would need the other's not-yet-final hash — mutually recursive, no fixed point, for monoco or any other tool. Previously `topoOrder` **silently dropped** cycle members from the plan; now the planner separates true cycle members from modules merely downstream of the cycle and refuses with the member list and the `--bump <module>=skip` remedy (release one side at a time, pinned to the other's previous tag — the same convention cyclic Go modules already use).

## Docs

- `docs/release-model.md`: why one commit can carry every tag (tag → commit resolution removes the chicken-and-egg), hash-ordering rationale, and a "Require cycles are refused" section.
- `README.md`: stale "major bumps are refused" claims replaced with the implemented `--allow-major` flow; v0 `major`→`minor` coercion documented; require-cycle convention added; note that `release` needs `go.work`/`go.work.sum` committed; note on why task fanout exists (golang/go#50745).

## Regression coverage

- `TestRewriteGoMods_SumEntriesMatchPostRewriteContent`: a consumer's `go.sum` entry must equal the canonical hash of the dependency's post-rewrite directory. Fails on the old code, passes with the fix.
- `TestNewPlanForModules_requireCycleError`: cycle refused naming exactly the cycle members (not downstream modules); skipping one side unblocks the plan.

Verified end-to-end by re-running the production simulation: released versions published to a file proxy from the release tag, then module-mode builds of every chain member — Go verifies monoco's precomputed hashes against the canonical zips cleanly, and `go mod tidy` works.

Full suite: `go test ./... -count=1` and `go vet ./...` green.

https://claude.ai/code/session_01KmCLYi4eeDrhoYy5PDmbvR