### PR TITLE
docs: add operations guide; sync README and docs with current CLI surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ We do not invent new build paradigms, override compiler behavior, or require use
 
 - `cmd/monoco/` — CLI entrypoint and subcommand wiring.
 - `internal/workspace/` — `go.work` discovery and module enumeration.
+- `internal/gitx/` — shared git CLI invocation helper (uniform error shapes, ctx cancellation).
 - `internal/gitgraph/` — reverse dependency graph derived from `go.mod` requires.
 - `internal/affected/` — direct-affected (replace-directive) and cascaded-affected computation.
 - `internal/propagate/` — `go.mod` / `go.sum` rewrites; in-process `h1:` hashing.
@@ -33,7 +34,7 @@ We do not invent new build paradigms, override compiler behavior, or require use
 - `internal/config/` — `monoco.yaml` loader (optional; sane defaults).
 - `internal/tasks/` — test / lint / build / generate fanout over the affected set.
 - `internal/fixture/` — local git-repo fixtures for end-to-end tests.
-- `docs/` — technical documentation ([architecture](docs/architecture.md), [release model](docs/release-model.md), [POC findings](docs/poc-findings.md)).
+- `docs/` — technical documentation ([architecture](docs/architecture.md), [release model](docs/release-model.md), [operations](docs/operations.md), [POC findings](docs/poc-findings.md)).
 - `test/integration/` — integration suite against a real GitHub test monorepo (tag: `integration`).
 
 ## Development commands

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ monoco release -y --bump modules/storage=minor
 
 # Drop a module from this release:
 monoco release -y --bump modules/storage=skip
+
+# Release a module nothing in-repo depends on — naming it in --bump
+# adds it to the release, no replace directive needed:
+monoco release -y --bump modules/cli=minor
 ```
 
 Also useful:
@@ -50,6 +54,10 @@ monoco test --since origin/main         # run tests only where it matters
 monoco lint --since origin/main
 monoco build --since origin/main
 monoco generate --since origin/main
+
+monoco test --all                       # every workspace module, not just affected
+monoco test --since origin/main -- -race -count=1   # args after -- are appended
+                                                    # to the task command
 ```
 
 The fanout commands exist because `go build ./...` at the workspace root
@@ -98,7 +106,7 @@ Gotchas worth flagging when you copy it:
 - Each release gets a train tag pointing at the same release commit: `train/2026-04-18-<slug>`.
 - Release commit message: `release: train/<date>-<slug>`.
 - **Bump kinds default to `patch`** for every module in the plan. Override per-module with `--bump <module>=<minor|major|skip>`. No commit-message inference, no prompting, no Conventional Commits dependency.
-- A **direct-affected** module is one whose source is under active local development, identified by the presence of a workspace-local `replace` directive pointing at it from any sibling module's `go.mod`.
+- A **direct-affected** module is one whose source is under active local development, identified by the presence of a workspace-local `replace` directive pointing at it from any sibling module's `go.mod`. Naming a module in `--bump` (any kind but `skip`) also adds it to the direct set — that's how you release a module no sibling depends on, like a CLI or an externally consumed library.
 - A **cascaded** module is a consumer of a direct-affected module. It gets the same default-patch treatment as directs; override with `--bump` if needed.
 - Major-version boundary crossings need an explicit opt-in: `--allow-major <module>` (or `allow_major` in `monoco.yaml`). monoco then rewrites the `/vN` suffix across the bumper's `module` line and every consumer's `require` + imports. At most one module per release may cross.
 - On a v0 module, `--bump <module>=major` coerces to a minor bump (`v0.2.0 → v0.3.0`) — v0 is explicitly unstable in Go's semver convention, so there's no boundary to cross. Bump to `v1` by tagging `<module>/v1.0.0` by hand once, then let monoco take over.
@@ -118,7 +126,7 @@ Every `release` is one atomic operation:
 7. Tag every module in the plan at its stage's commit + a train tag at the tip.
 8. `git push --atomic origin <branch> <tags...>` — all or nothing.
 
-If anything before the push fails, the working tree and refs are restored to their pre-run state. If the push fails, the local commit and tags are kept; rerun `release` after fixing the push condition.
+If anything before the push fails, the working tree and refs are restored to their pre-run state. If the push itself fails, the local commit and tags are kept: re-push them by hand after a transient failure, or unwind (`git tag -d` + `git reset --hard`) and re-plan if the remote moved ahead — see [docs/operations.md](docs/operations.md#failure-modes-and-recovery) for the exact recovery steps and an error-by-error troubleshooting table.
 
 Step 6 runs `go build` with `GOWORK=off` and `GOFLAGS=-mod=mod` so the verify pass sees the same module graph `go get` consumers will see; see [docs/release-model.md](docs/release-model.md) for the rationale.
 
@@ -179,6 +187,11 @@ exclude: []
 # (go test ./..., golangci-lint run, go build ./..., go generate ./...).
 tasks: {}
 
+# Module paths permitted to cross a major version boundary (/vN path
+# rewrite). Unioned with the --allow-major flag; at most one module per
+# release may cross.
+allow_major: []
+
 # Branches `monoco release` may push to besides the remote's default
 # branch (glob patterns, e.g. release-*). Releases always push directly
 # to a long-lived branch; PR branches are refused.
@@ -209,6 +222,7 @@ Excluded modules never show up in `monoco affected`, `monoco release`, or task f
 
 - [Architecture](docs/architecture.md) — package map and data flow.
 - [Release model](docs/release-model.md) — cascade, verification, atomic push.
+- [Operations](docs/operations.md) — setup, day-to-day usage, failure recovery, troubleshooting.
 - [POC findings](docs/poc-findings.md) — why the v1 design landed where it did.
 - Tests: `go test ./...`. End-to-end (local-fixture): `go test ./cmd/monoco/... -count=1`.
 - Integration (against the real GitHub test monorepo) runs on every push to `main` via `.github/workflows/integration.yml`. To run locally: `MONOCO_TEST_REPO_TOKEN=<PAT> go test -tags=integration ./test/integration/... -v`. See [test/integration/README.md](test/integration/README.md) for the scenario matrix and troubleshooting.

--- a/cmd/monoco/main.go
+++ b/cmd/monoco/main.go
@@ -124,6 +124,12 @@ version: 1
 #   lint:
 #     command: ["golangci-lint", "run", "--timeout=5m"]
 
+# Module paths permitted to cross a major version boundary (/vN path
+# rewrite). Unioned with the --allow-major flag; at most one module per
+# release may cross.
+# allow_major:
+#   - github.com/org/repo/modules/storage
+
 # Branches monoco release may push to besides the remote's default
 # branch (glob patterns). Releases always push directly to a long-lived
 # branch; releasing from a PR branch is refused because squash/rebase

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,9 +25,15 @@ Parses `go.work`, enumerates workspace modules, and builds the workspace-interna
 
 Only edges whose target is itself a workspace module (has a `use` entry in `go.work`) are kept. External deps are irrelevant to monoco's job.
 
+### `internal/gitx`
+
+The single shared helper for invoking the git CLI: `gitx.Run` executes `git -C <root> <args...>` and returns trimmed stdout. Exists so `gitgraph`, `propagate`, and `release` produce identical error shapes (args + stderr in the error) and respect context cancellation uniformly.
+
+**API:** `Run`.
+
 ### `internal/gitgraph`
 
-Read-only git operations: commit range enumeration, touched-file listing, latest-tag lookup per module prefix. Shells out to `git` directly.
+Read-only git operations: commit range enumeration, touched-file listing, latest-tag lookup per module prefix. Shells out to `git` via `gitx`.
 
 **API:** `CommitsInRange`, `TouchedFiles`, `LatestTagForModule`.
 
@@ -47,7 +53,7 @@ Owns semver bump kinds: `Major`, `Minor`, `Patch`, `Skip`. Pre-1.0 versions trea
 
 Loads the optional `monoco.yaml`. Absence is equivalent to zero-config defaults — convention beats configuration.
 
-**API:** `Config` with `Exclude`, `Tasks`, `AllowMajor` fields.
+**API:** `Config` with `Exclude`, `Tasks`, `AllowMajor`, `ReleaseBranches` fields.
 
 ### `internal/propagate`
 
@@ -63,7 +69,7 @@ The heavy lifter. Two phases:
 
 ### `internal/release`
 
-The `monoco release` orchestrator. Detects direct-affected modules from workspace-local `replace` directives, applies bump kinds (default `patch`, overridable via `--bump`), and delegates the rewrite/commit/tag/push to `propagate`.
+The `monoco release` orchestrator. Detects direct-affected modules from workspace-local `replace` directives (unioned with modules named explicitly in `--bump`), applies bump kinds (default `patch`, overridable via `--bump`), enforces the long-lived-branch contract, and delegates the rewrite/commit/tag/push to `propagate`.
 
 **API:** `Options`, `Plan`, `Apply`, `CurrentVersions`.
 
@@ -105,7 +111,7 @@ bump.NextVersion       — apply bump kinds per module
   ↓
 propagate.ComputeRewrites  — new go.mod/go.sum content + tag names
   ↓
-dry-run stops here; --yes continues ↓
+dry-run stops here; -y or the Proceed? confirmation continues ↓
   ↓
 propagate.Apply:
   1. Write rewrites to disk

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,156 @@
+# Operations
+
+Setting up monoco, running it day to day, and recovering when something fails.
+
+This is the practical companion to [architecture.md](architecture.md) (how the code is organized) and [release-model.md](release-model.md) (what a release means). If an error message brought you here, jump to [Troubleshooting](#troubleshooting).
+
+## Setup
+
+### Requirements
+
+- Go 1.22+.
+- git 2.4+ (`git push --atomic` is the publish primitive).
+- For releases: push access to the repo's long-lived branch — the remote's default branch, or one matching a `release_branches` glob in `monoco.yaml`. Releases never go through PRs; see [release-model.md](release-model.md#direct-push-is-the-contract).
+- `golangci-lint` on `PATH` only if you use `monoco lint` with its default command.
+
+### First-time setup in a repo
+
+```bash
+go install github.com/matt0x6f/monoco/cmd/monoco@latest
+
+cd <repo-root>
+monoco init
+```
+
+`monoco init` does two things:
+
+1. Writes `go.work` with a `use` entry for every directory containing a `go.mod` (skipping `vendor/`, dotted directories, and the repo root's own `go.mod` if present).
+2. Writes a commented `monoco.yaml` stub if none exists. The stub is entirely optional — deleting it changes nothing.
+
+Commit `go.work` (and `go.work.sum`, once workspace commands create it): `release` requires a clean working tree, so untracked workspace files block it.
+
+After moving, adding, or deleting modules, run `monoco sync` (an alias of `init`, idempotent) to refresh `go.work`.
+
+### CI setup
+
+See the [README's CI section](../README.md#using-monoco-in-ci) and the reference workflow at `.github/workflows/monoco-release.yml.example`. The two non-obvious requirements, repeated here because they fail silently or late:
+
+- `actions/checkout` needs `fetch-depth: 0`. `--since` walks real history; a shallow clone silently shrinks the affected set or errors with `unknown revision`.
+- The release job's token needs `contents: write` and, under branch protection, a bypass (GitHub App token or PAT) — monoco pushes the release commit and tags directly.
+
+## Day-to-day operation
+
+### During development
+
+Pin in-flight modules with a workspace-local `replace` so the repo builds against your uncommitted work:
+
+```go
+// modules/api/go.mod
+replace github.com/org/repo/modules/storage => ../storage
+```
+
+This is plain Go — the workspace compiles with or without monoco. At release time monoco reads these directives as the declaration of what's shipping.
+
+### Checking what's affected, running tasks
+
+```bash
+monoco affected --since origin/main   # transitive-affected module set for the range
+monoco test     --since origin/main   # go test ./... in each affected module
+monoco lint     --since origin/main   # golangci-lint run (override via monoco.yaml)
+monoco build    --since origin/main
+monoco generate --since origin/main
+```
+
+Task-command flags:
+
+- `--since <ref>` — base ref for the affected computation (branch, remote ref, or SHA). Required unless `--all` is given.
+- `--all` — fan out over every workspace module instead of the affected set.
+- Arguments after `--` are appended to the task's command, e.g. `monoco test --since origin/main -- -race -count=1` runs `go test ./... -race -count=1` per module.
+
+Tasks run in parallel across modules; output is grouped per module with an `ok`/`FAIL` marker, and the exit code is non-zero if any module failed.
+
+### Cutting a release
+
+```bash
+monoco release --dry-run                       # preview the plan, mutate nothing
+monoco release -y                              # everything defaults to a patch bump
+monoco release -y --bump modules/storage=minor # override a module's bump kind
+monoco release -y --bump modules/storage=skip  # drop a module from the plan
+monoco release -y --bump modules/cli=minor     # release a module nothing in-repo
+                                               # depends on (no replace needed)
+```
+
+Release flags:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--bump <module>=<kind>` (repeatable) | every module `patch` | Override the bump kind: `major`, `minor`, `patch`, or `skip`. Naming a module here (any kind but `skip`) also adds it to the release even if no sibling `replace`s it. |
+| `--allow-major <module>` (repeatable) | none | Permit the module to cross a `/vN` major boundary. Unioned with `allow_major` in `monoco.yaml`. At most one module per release may cross. |
+| `--cut <module>` (repeatable) | auto | In a require cycle, force which member releases first (pinned to its partners' previous tags). |
+| `--remote <name>` | `origin` | Push target. `--remote ""` skips the push: the release commit and tags are created locally only. |
+| `--slug <slug>` | current branch name | Train-tag slug: `train/<YYYY-MM-DD>-<slug>`. |
+| `--dry-run` | off | Print the plan and exit. Offline — no `ls-remote` — except that a plan containing a require cycle runs `go build` to pick the staging order. |
+| `-y` | off | Skip the `Proceed? [y/N]` confirmation. |
+
+Module references in `--bump`, `--allow-major`, and `--cut` accept either the module path (the `go.mod` `module` line) or the repo-relative directory (as it appears in `go.work`'s `use` entries) — `modules/storage` works for both forms.
+
+Preconditions checked before anything is mutated:
+
+- The working tree is clean (`git status --porcelain` empty).
+- When pushing, the current branch is the remote's default branch or matches a `release_branches` glob.
+- When pushing, the remote branch hasn't moved since the plan was computed (re-checked again at push time via a lease).
+
+On success the output reports the release commit SHA, the number of tags created, and whether the push happened. Confirm from anywhere with `git ls-remote --tags origin 'modules/*'`.
+
+## Failure modes and recovery
+
+`release` has a two-phase recovery contract:
+
+**Any failure before the push** — preflight, rewrite, verify, commit, tag — rolls back automatically: locally created tags are deleted and the working tree is reset to the pre-run HEAD. There is nothing to clean up; fix the cause and rerun.
+
+**A failure of the push itself** leaves the local release commit and tags intact (the work is correct; only publishing failed). Re-running `monoco release` at this point reports "nothing to release" — the release commit already stripped the `replace` directives — so recover one of two ways:
+
+- *Transient failure* (network, auth, branch-protection token): re-push the same refs by hand. All of them exist locally:
+
+  ```bash
+  git push --atomic origin <branch> <module tags...> train/<date>-<slug>
+  ```
+
+- *Remote moved ahead* (non-fast-forward / lease broken): do **not** rebase the release commit — tags pin SHAs and would be orphaned by the rewrite. Unwind and re-plan instead:
+
+  ```bash
+  git tag -d <module tags...> train/<date>-<slug>
+  git reset --hard <pre-release HEAD>
+  git pull origin <branch>
+  monoco release ...
+  ```
+
+Note on protected branches: monoco pushes with `--force-with-lease` when it holds a base SHA; if the remote's protection rules reject lease pushes outright, it falls back to a plain atomic push (a non-fast-forward is still rejected, so the race protection holds).
+
+## Troubleshooting
+
+Errors below are quoted as monoco prints them (prefixed `monoco:`). Errors from the Go toolchain and git propagate with context rather than being reinterpreted — a compile error during verify is a real compile error in your code.
+
+| Error / symptom | Cause | Fix |
+|---|---|---|
+| `working tree is not clean: ...` | Uncommitted or untracked files (often `go.work.sum`). | Commit or stash. `go.work` and `go.work.sum` belong in the repo. |
+| `no modules have workspace-local replace directives and no --bump overrides; nothing to release.` | monoco found nothing declaring intent to ship. | Add a workspace-local `replace` to a consumer's `go.mod`, or name the module explicitly: `--bump <module>=<kind>`. |
+| `refusing to release from branch "x": releases push directly to a long-lived branch ...` | You're on a feature/PR branch. Tags cut there are orphaned by squash/rebase merges. | Release from the default branch (after merging), or add the branch to `release_branches` in `monoco.yaml` if it's a long-lived maintenance branch. |
+| `module X would cross major version boundary (v1.9.0 → v2.0.0); pass --allow-major X or set allow_major in monoco.yaml` | Major bumps rewrite the `/vN` path across the module and every consumer — heavy, so it's opt-in. | Add `--allow-major <module>` or the `allow_major` manifest entry. |
+| `at most one module per propagation may cross a major boundary; got: ...` | Two or more `/vN` crossings in one plan. | Split into separate releases. |
+| `--bump "x=y": module "x" not found in workspace` (also for `--allow-major`, `--cut`, `allow_major`) | Typo, or the module isn't in `go.work`. | Use the module path or the repo-relative directory. `monoco sync` if the module is new. |
+| `base moved: origin refs/heads/main was <sha> when plan was computed, now <sha>; re-run 'monoco release' and retry` | Someone pushed to the base branch between plan and apply. Caught before any mutation. | Pull, rerun `monoco release`. |
+| `atomic push: ...` | The push itself failed: remote advanced, branch protection, network, auth. Local commit and tags are kept. | See [Failure modes and recovery](#failure-modes-and-recovery). |
+| `verify build in <dir>: ... stderr: <compile error>` | A rewrite produced an incoherent module — downstream code doesn't compile against the new upstream in module mode (workspace mode was hiding it). Rolled back automatically. | Fix the source (usually the downstream caller), commit, rerun. The compile error names the symbol. |
+| `cannot stage require cycle: X requires Y@<version>, which is not a tag in this repository` | A require cycle can only be staged against previously *tagged* content; the pinned version was never tagged (e.g. bootstrap placeholders). | Tag the partner once by hand, or break the cycle in code. |
+| `module X is in a require cycle and would cross a major version boundary` | A `/vN` rewrite can't apply across a pinned cycle back-edge. | Break the cycle first; release the major bump separately. |
+| `--cut X: not part of a require cycle in this plan` | `--cut` only chooses an ordering within a cycle. | Drop the flag, or check the plan actually contains the cycle you think it does. |
+| Release-coupled cycle error (no member of the cycle compiles against the other's previous tag) | Each side needs the other's *new* API — no staged order works, for monoco or by hand. | The cycle is one module pretending to be two: merge the modules or break the cycle. `--bump <module>=skip` drops one side as a stopgap. |
+| `affected`/`test` with `--since` errors with `unknown revision`, or the affected set looks too small | Shallow clone, or the base ref isn't fetched. | `git fetch origin main` locally; `fetch-depth: 0` in CI. |
+| `monoco lint` fails with `executable file not found` | Default lint command is `golangci-lint run` and the binary isn't installed. | Install golangci-lint, or override `tasks.lint.command` in `monoco.yaml`. |
+| Excluded module still being tagged / still in the affected set | `exclude` entries are repo-relative directories matching `go.work` `use` entries, not module paths. | Use the directory form (`modules/foo`), then re-check with `monoco affected`. |
+| `monoco.yaml: ... field <x> not found` | Unknown keys are rejected (typo guard), as are unknown task names. | Valid keys: `version`, `exclude`, `tasks` (test/lint/build/generate), `allow_major`, `release_branches`. |
+
+## Uninstalling
+
+Delete the binary and `monoco.yaml`. Everything else monoco touched is standard Go and git: `go.work`, `go.mod`, `go.sum`, semver tags. Nothing to migrate, nothing breaks — that's the [leave-ability contract](release-model.md#leave-ability).

--- a/docs/release-model.md
+++ b/docs/release-model.md
@@ -33,6 +33,8 @@ replace github.com/org/repo/modules/storage => ../storage
 
 That `replace` is the user's declaration of "storage is shipping in this release." During development it lets the workspace compile against uncommitted changes; at release time monoco reads it as intent.
 
+The direct set is the union of two sources: modules detected from `replace` directives, and modules named explicitly via `--bump <module>=<kind>` (any kind but `skip`). The second source exists because a module is releasable regardless of whether anything in the same repo depends on it — a CLI, or a library published only for external consumers, has no in-tree `replace` pointing at it.
+
 All directly-affected modules are then expanded transitively to **cascaded** consumers via the reverse-dep graph. Both sets get the same treatment — default `patch` bump, overridable with `--bump <module>=<kind>` (or `=skip` to drop).
 
 ## The bump plan
@@ -41,7 +43,7 @@ All directly-affected modules are then expanded transitively to **cascaded** con
 - Override per-module: `--bump modules/storage=minor`, `--bump modules/api=major`, `--bump modules/utils=skip`.
 - No commit-message inference, no Conventional Commits parsing, no prompting beyond the final `Proceed?`.
 - Pre-1.0 versions coerce `Major` → `Minor` (Go's standard semver convention).
-- At most one module per release may cross a major-version boundary (the `/vN` path rewrite is heavy; see `internal/propagate/importrewrite/`). Modules opting in must be listed in `monoco.yaml`'s `AllowMajor`.
+- At most one module per release may cross a major-version boundary (the `/vN` path rewrite is heavy; see `internal/propagate/importrewrite/`). Modules opting in must be named with `--allow-major <module>` or listed in `monoco.yaml`'s `allow_major`; the union of both applies.
 
 ## Tag naming
 
@@ -121,7 +123,7 @@ Concretely, when a push is intended (`--remote` set), `release` requires the cur
 
 If branch protection forbids all direct pushes, give the release job a bypass (a GitHub App token or PAT with `contents: write`) rather than routing the release through a PR. A strict no-bypass, squash-only policy is the one configuration monoco's model cannot serve.
 
-Before the push, if any step fails (rewrite, verify, commit, tag), the working tree and refs are restored to their pre-run state. If the push itself fails, the local release commit and tags are kept; rerun `release` after fixing the push condition (e.g., the remote moved ahead, TOCTOU lease broken).
+Before the push, if any step fails (rewrite, verify, commit, tag), the working tree and refs are restored to their pre-run state. If the push itself fails, the local release commit and tags are kept — the work is correct, only publishing failed. After a transient failure, re-push the same refs by hand; if the remote moved ahead, unwind (delete the local tags, reset to the pre-release HEAD) and re-plan — never rebase a release commit, since tags pin SHAs. Step-by-step recovery lives in [operations.md](operations.md#failure-modes-and-recovery).
 
 ## TOCTOU protection
 

--- a/internal/propagate/apply.go
+++ b/internal/propagate/apply.go
@@ -63,7 +63,7 @@ func ApplyContext(ctx context.Context, ws *workspace.Workspace, plan *Plan, opts
 			return nil, fmt.Errorf("recheck %s %s: %w", opts.Remote, plan.BaseRef, err)
 		}
 		if cur != plan.BaseSHA {
-			return nil, fmt.Errorf("base moved: %s %s was %s when plan was computed, now %s; re-run 'monoco propagate plan' and retry", opts.Remote, plan.BaseRef, plan.BaseSHA, cur)
+			return nil, fmt.Errorf("base moved: %s %s was %s when plan was computed, now %s; re-run 'monoco release' and retry", opts.Remote, plan.BaseRef, plan.BaseSHA, cur)
 		}
 	}
 


### PR DESCRIPTION
Audits the README and `docs/` against the current code and fills the gaps around setup, operation, and troubleshooting.

## New: `docs/operations.md`

A practical runbook covering:
- **Setup** — requirements, first-time `monoco init` flow, what to commit, CI requirements.
- **Day-to-day operation** — replace-directive workflow, task fanout flags, a full `release` flag reference table, and the preconditions checked before any mutation.
- **Failure modes and recovery** — the two-phase contract (pre-push failures roll back automatically; push failures keep the local commit + tags), with exact recovery steps for transient push failures vs. a moved remote. Notably documents that re-running `monoco release` after a push failure reports "nothing to release" (the release commit already stripped the replaces), so the previous "rerun release" guidance in README/release-model was corrected.
- **Troubleshooting table** — actual error messages mapped to cause and fix.

## Doc fixes for drift found during the audit

- **README**: `--bump <module>=<kind>` alone adds a module to the release (no replace directive needed — how you ship a module nothing in-repo depends on); task `--all` flag and `--` arg passthrough; `allow_major` added to the manifest defaults block (it was documented elsewhere but missing there).
- **release-model.md**: direct set is the union of replace-detected modules and explicit `--bump` entries; major-boundary opt-in is `--allow-major` *or* `allow_major` (union).
- **architecture.md**: adds the `internal/gitx` package (extracted in #48 but never documented), `ReleaseBranches` in the config API, and the real `-y` flag name in the data-flow diagram.
- **AGENTS.md**: layout now lists `internal/gitx` and the new operations doc.

## Two small code touch-ups surfaced by the audit

- `internal/propagate/apply.go`: the "base moved" error told users to re-run `monoco propagate plan`, a command removed before v1 — now says `monoco release`.
- `cmd/monoco/main.go`: the `monoco init` manifest stub gains a commented `allow_major` section (it covered every other manifest key).

`go build ./...`, `go vet ./...`, and the full test suite pass (the sandbox's forced commit-signing config breaks `internal/gitx` tests regardless of branch; they pass with `GIT_CONFIG_GLOBAL=/dev/null`).

https://claude.ai/code/session_01S8q2GhKi46j39atcZtMmFi

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8q2GhKi46j39atcZtMmFi)_